### PR TITLE
Add --pip-args and --pip3-args

### DIFF
--- a/colcon_bundle/installer/pip.py
+++ b/colcon_bundle/installer/pip.py
@@ -26,8 +26,11 @@ class PipBundleInstallerExtensionPoint(BundleInstallerExtensionPoint):
 
     def add_arguments(self, *, parser):  # noqa: D102
         parser.add_argument(
-            '--pip-argument', default='build',
-            help='The base path for all build directories (default: build)')
+            '--pip-args',
+            nargs='*', metavar='*', type=str.lstrip,
+            help='Pass arguments to CMake projects. '
+            'Arguments matching other options in colcon must be prefixed '
+            'by a space,\ne.g. --pip-args " --help"')
 
     def initialize(self, context):  # noqa: D102
         self.context = context
@@ -61,9 +64,9 @@ class PipBundleInstallerExtensionPoint(BundleInstallerExtensionPoint):
         with open(requirements, 'w') as req:
             for name in self._packages:
                 req.write(name.strip() + '\n')
-
-        subprocess.check_call(
-            [python_path, '-m', 'pip', 'install', '--ignore-installed',
-             '-r', requirements])
+        pip_args = [python_path, '-m', 'pip', 'install', '--ignore-installed']
+        pip_args += (self.context.args.pip_args or [])
+        pip_args += ['-r', requirements]
+        subprocess.check_call(pip_args)
 
         return {'requirements': self._packages}

--- a/test/test_pip_installer.py
+++ b/test/test_pip_installer.py
@@ -4,11 +4,11 @@ import shutil
 import os
 
 from colcon_bundle.installer import BundleInstallerContext
-from colcon_bundle.installer.pip3 import Pip3BundleInstallerExtensionPoint
+from colcon_bundle.installer.pip import PipBundleInstallerExtensionPoint
 
 
 def test_install_nothing():
-    installer = Pip3BundleInstallerExtensionPoint()
+    installer = PipBundleInstallerExtensionPoint()
     context = BundleInstallerContext(
         args=None, cache_path=None, prefix_path=None)
     installer.initialize(context)
@@ -18,12 +18,12 @@ def test_install_nothing():
 
 @patch('subprocess.check_call')
 def test_install(check_call):
-    installer = Pip3BundleInstallerExtensionPoint()
+    installer = PipBundleInstallerExtensionPoint()
     cache_dir = mkdtemp()
     prefix = mkdtemp()
-    python_path = os.path.join(prefix, 'usr', 'bin', 'python3')
+    python_path = os.path.join(prefix, 'usr', 'bin', 'python2')
     context_args = Mock()
-    context_args.pip3_args = []
+    context_args.pip_args = []
     context = BundleInstallerContext(
         args=context_args, cache_path=cache_dir, prefix_path=prefix)
     try:
@@ -55,12 +55,12 @@ def test_install(check_call):
 
 @patch('subprocess.check_call')
 def test_install_with_additional_arguments(check_call):
-    installer = Pip3BundleInstallerExtensionPoint()
+    installer = PipBundleInstallerExtensionPoint()
     cache_dir = mkdtemp()
     prefix = mkdtemp()
-    python_path = os.path.join(prefix, 'usr', 'bin', 'python3')
+    python_path = os.path.join(prefix, 'usr', 'bin', 'python2')
     context_args = Mock()
-    context_args.pip3_args = [' --test-arg-1', '--test-arg-2']
+    context_args.pip_args = [' --test-arg-1', '--test-arg-2']
     context = BundleInstallerContext(
         args=context_args, cache_path=cache_dir, prefix_path=prefix)
     try:


### PR DESCRIPTION
Adds --pip-args and --pip3-args which behave exactly like --cmake-args in the colcon-cmake package. When used, the arguments are passed directly to pip/pip3. This will allow users to use arguments like '--index-url' to install from custom Python repositories.