### PR TITLE
Update pip installer to not install if dependencies didn't change

### DIFF
--- a/colcon_bundle/installer/base_pip_installer.py
+++ b/colcon_bundle/installer/base_pip_installer.py
@@ -1,6 +1,7 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 import subprocess
 
@@ -53,21 +54,49 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
             return {'installed_packages': []}
 
         logger.info('Installing pip3 dependencies...')
+
+        requirements_file = os.path.join(self._cache_path, 'requirements')
+        metadata_file = os.path.join(self._cache_path, 'metadata')
+
+        if os.path.exists(requirements_file):
+            with open(requirements_file, 'r') as req:
+                existing_requirements = list(map(str.strip, req.readlines()))
+                if existing_requirements == self._packages:
+                    logger.info(
+                        'No changes detected for {}'.format(self._python_path))
+                    if os.path.exists(metadata_file):
+                        with open(metadata_file, 'r') as f:
+                            metadata = json.load(f)
+                            return metadata
+
         python_pip_args = [self._python_path, '-m', 'pip']
         pip_install_args = python_pip_args + ['install']
         subprocess.check_call(pip_install_args + ['-U', 'pip', 'setuptools'])
 
-        requirements = os.path.join(self._cache_path, 'requirements')
-        with open(requirements, 'w') as req:
+        with open(requirements_file, 'w') as req:
             for name in self._packages:
                 req.write(name.strip() + '\n')
 
         pip_args = []
         pip_args += pip_install_args
         pip_args += (self._pip_args or [])
-        pip_args += ['--ignore-installed', '-r', requirements]
+        pip_args += ['--ignore-installed', '-r', requirements_file]
         subprocess.check_call(pip_args)
 
+        # https://pip.pypa.io/en/stable/reference/pip_download/
+        if self.context.args.include_sources:
+            sources_path = os.path.join(self._cache_path, 'sources')
+            download_args = python_pip_args + [
+                'download', '--no-binary', ':all',
+                '-d', sources_path, '-r', requirements_file]
+            subprocess.check_call(download_args)
+
+        metadata = self._generate_metadata(python_pip_args)
+        with open(metadata_file, 'w') as f:
+            json.dump(metadata, f)
+        return metadata
+
+    def _generate_metadata(self, python_pip_args):
         pip_freeze_args = python_pip_args + ['freeze']
 
         freeze_output = subprocess.check_output(
@@ -76,16 +105,7 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
         installed = list(map(
             self.split_package_version,
             filter(lambda s: s != '', freeze_output.split('\n'))))
-        metadata = {'installed_packages': installed}
-
-        # https://pip.pypa.io/en/stable/reference/pip_download/
-        if self.context.args.include_sources:
-            sources_path = os.path.join(self._cache_path, 'sources')
-            download_args = python_pip_args + [
-                'download', '--no-binary', ':all',
-                '-d', sources_path, '-r', requirements]
-            subprocess.check_call(download_args)
-        return metadata
+        return {'installed_packages': installed}
 
     @staticmethod
     def split_package_version(package_version):

--- a/test/test_pip3_installer.py
+++ b/test/test_pip3_installer.py
@@ -113,3 +113,59 @@ def test_install_with_additional_arguments(check_output, check_call):
     finally:
         shutil.rmtree(cache_dir)
         shutil.rmtree(prefix)
+
+
+@patch('subprocess.check_call')
+@patch('subprocess.check_output')
+def test_install_not_required(check_output, check_call):
+    installer = Pip3BundleInstallerExtensionPoint()
+    cache_dir = mkdtemp()
+
+    prefix = mkdtemp()
+    python_path = os.path.join(prefix, 'usr', 'bin', 'python3')
+    context_args = Mock()
+    context_args.pip3_args = []
+    context = BundleInstallerContext(
+        args=context_args, cache_path=cache_dir, prefix_path=prefix)
+    check_output.return_value = 'pkg1==3.4.5\npkg2==3.1.2\n'
+    try:
+        installer.initialize(context)
+        installer.add_to_install_list('pkg1==3.4.5')
+        installer.add_to_install_list('pkg2>=3.1.2')
+        installer.add_to_install_list('remove_me')
+        installer.remove_from_install_list('remove_me')
+        result = installer.install()
+
+        args_list = check_call.call_args_list
+        args = args_list[0][0][0]
+        assert args[0] == python_path
+        # Ensure we upgrade pip/setuptools
+        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+
+        args = args_list[1][0][0]
+        assert args[0] == python_path
+        assert args[1:-1] == [
+            '-m', 'pip', 'install', '--ignore-installed', '-r']
+
+        assert result == {
+            'installed_packages': [
+                {
+                    'name': 'pkg1',
+                    'version': '3.4.5'
+                },
+                {
+                    'name': 'pkg2',
+                    'version': '3.1.2'
+                }
+            ]
+        }
+
+        result_2 = installer.install()
+        assert result == result_2
+        # Verify we haven't called pip
+        assert check_call.call_count == 3
+        # Verify we haven't called pip freeze
+        assert check_output.call_count == 1
+    finally:
+        shutil.rmtree(cache_dir)
+        shutil.rmtree(prefix)

--- a/test/test_pip_installer.py
+++ b/test/test_pip_installer.py
@@ -113,3 +113,58 @@ def test_install_with_additional_arguments(check_output, check_call):
     finally:
         shutil.rmtree(cache_dir)
         shutil.rmtree(prefix)
+
+@patch('subprocess.check_call')
+@patch('subprocess.check_output')
+def test_install_not_required(check_output, check_call):
+    installer = PipBundleInstallerExtensionPoint()
+    cache_dir = mkdtemp()
+
+    prefix = mkdtemp()
+    python_path = os.path.join(prefix, 'usr', 'bin', 'python2')
+    context_args = Mock()
+    context_args.pip_args = []
+    context = BundleInstallerContext(
+        args=context_args, cache_path=cache_dir, prefix_path=prefix)
+    check_output.return_value = 'pkg1==3.4.5\npkg2==3.1.2\n'
+    try:
+        installer.initialize(context)
+        installer.add_to_install_list('pkg1==3.4.5')
+        installer.add_to_install_list('pkg2>=3.1.2')
+        installer.add_to_install_list('remove_me')
+        installer.remove_from_install_list('remove_me')
+        result = installer.install()
+
+        args_list = check_call.call_args_list
+        args = args_list[0][0][0]
+        assert args[0] == python_path
+        # Ensure we upgrade pip/setuptools
+        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+
+        args = args_list[1][0][0]
+        assert args[0] == python_path
+        assert args[1:-1] == [
+            '-m', 'pip', 'install', '--ignore-installed', '-r']
+
+        assert result == {
+            'installed_packages': [
+                {
+                    'name': 'pkg1',
+                    'version': '3.4.5'
+                },
+                {
+                    'name': 'pkg2',
+                    'version': '3.1.2'
+                }
+            ]
+        }
+
+        result_2 = installer.install()
+        assert result == result_2
+        # Verify we haven't called pip
+        assert check_call.call_count == 3
+        # Verify we haven't called pip freeze
+        assert check_output.call_count == 1
+    finally:
+        shutil.rmtree(cache_dir)
+        shutil.rmtree(prefix)


### PR DESCRIPTION
This is similar logic to how the apt installer chooses not to run. This should save time when pip dependencies aren't changing.