### PR TITLE
Fix offset metadata of overlays

### DIFF
--- a/BUNDLE_FORMAT.md
+++ b/BUNDLE_FORMAT.md
@@ -123,13 +123,13 @@ size is bytes.
 	{
 		"overlays": [
 			{
-				"file_name": "bundle.tar.gz",
+				"name": "bundle.tar.gz",
 				"sha256": "3c0f891fa2e98c125198afe250054609fd26e7462570ff6d3f6654625627cbf4",
 				"offset": 1000,
 				"size": 10000
 			},
 			{
-				"file_name": "install.tar.gz",
+				"name": "install.tar.gz",
 				"sha256": "650d05f59bc3d19c3871994e0261f7dfe790b050d5baf7c42a2c11f86ee39690",
 				"offset": 11000,
 				"size": 1000

--- a/test/test_bundlefile.py
+++ b/test/test_bundlefile.py
@@ -9,6 +9,9 @@ import pytest
 
 from colcon_bundle.verb.bundlefile import Bundle
 
+json_data = {'test': 1, 'test_2': 2,
+             'test_3': ['foo'], 'test_4': {'test_5': 1.3283}}
+
 
 class TestBundlefile:
     def setup_method(self, method):
@@ -19,21 +22,32 @@ class TestBundlefile:
 
     def test_bundlefile(self):
         bundle_path = os.path.join(self.tmpdir, 'test.mba')
-        file_path = os.path.join(self.tmpdir, 'file')
-        with open(file_path, 'w') as f:
-            f.write('{}')
+        json_file = os.path.join(self.tmpdir, 'file')
+        with open(json_file, 'w') as f:
+            f.write(json.dumps(json_data))
 
-        archive = os.path.join(self.tmpdir, 'dependencies.tar.gz')
-        with tarfile.open(archive, 'w:gz') as a:
-            a.add(file_path, arcname='file')
+        blocksize_file = os.path.join(self.tmpdir, 'blocksize_file')
+        with open(blocksize_file, 'wb') as f:
+            f.write(bytearray(tarfile.BLOCKSIZE))
 
-        other = os.path.join(self.tmpdir, 'other.tar.gz')
-        with tarfile.open(other, 'w:gz') as a:
-            a.add(file_path, arcname='file')
+        large_file = os.path.join(self.tmpdir, 'large_file')
+        with open(large_file, 'wb') as f:
+            large_file_size = 12 + tarfile.BLOCKSIZE * 1000
+            f.write(bytearray(large_file_size))
+
+        dep_archive = os.path.join(self.tmpdir, 'dependencies.tar.gz')
+        with tarfile.open(dep_archive, 'w:gz') as a:
+            a.add(json_file, arcname='file')
+
+        other_archive = os.path.join(self.tmpdir, 'other.tar.gz')
+        with tarfile.open(other_archive, 'w:gz') as a:
+            a.add(json_file, arcname='file2')
 
         with Bundle(name=bundle_path, mode='w') as bundle:
-            bundle.add_overlay_archive(archive)
-            bundle.add_overlay_archive(other)
+            bundle.add_overlay_archive(dep_archive)
+            bundle.add_overlay_archive(other_archive)
+            bundle.add_overlay_archive(blocksize_file)
+            bundle.add_overlay_archive(large_file)
 
         metadata_path = os.path.join(self.tmpdir, 'metadata.tar.gz')
         with tarfile.open(bundle_path, 'r:') as bundle:
@@ -48,7 +62,7 @@ class TestBundlefile:
 
         tar_header_size = 512
         offset = 4 * 1024 * 1024 + tar_header_size
-        size = os.stat(archive).st_size
+        size = os.stat(dep_archive).st_size
         with tarfile.open(metadata_path) as metadata_tar:
             members = metadata_tar.members
             contents = metadata_tar.extractfile(members[0])
@@ -59,10 +73,12 @@ class TestBundlefile:
             assert offset == overlays[0]['offset']
             assert size == overlays[0]['size']
             assert 64 == len(overlays[0]['sha256'])
-
             assert 'other.tar.gz' == overlays[1]['name']
-            assert offset + size + tar_header_size == overlays[1]['offset']
-            assert os.stat(other).st_size == overlays[1]['size']
+            other_offset = overlays[1]['offset']
+            assert os.stat(other_archive).st_size == overlays[1]['size']
+
+            assert overlays[2]['size'] == tarfile.BLOCKSIZE
+            assert overlays[3]['size'] == large_file_size
 
         with open(bundle_path, 'rb') as bundle:
             bundle.seek(offset)
@@ -70,7 +86,17 @@ class TestBundlefile:
             tar = tarfile.open(fileobj=deps)
             assert 'file' == tar.members[0].name
             json_buffer = tar.extractfile(tar.members[0])
-            json.loads(json_buffer.read().decode('utf-8'))
+            actual_data = json.loads(json_buffer.read().decode('utf-8'))
+            assert actual_data == json_data
+
+        with open(bundle_path, 'rb') as bundle:
+            bundle.seek(other_offset)
+            deps = BytesIO(bundle.read(size))
+            tar = tarfile.open(fileobj=deps)
+            assert 'file2' == tar.members[0].name
+            json_buffer = tar.extractfile(tar.members[0])
+            actual_data = json.loads(json_buffer.read().decode('utf-8'))
+            assert actual_data == json_data
 
     def test_bundlefile_metadata_over_4mb(self):
         file_size = 6 * 1024 * 1024 # size in bytes


### PR DESCRIPTION
Tar files write in 512 byte blocks. I was not taking that into account when computing the offset of subsequent overlays.

https://www.gnu.org/software/tar/manual/html_node/Blocking.html