### PR TITLE
Update colcon-core dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN	rosdep update && \
 
 RUN pip3 install --upgrade pip setuptools
 RUN pip3 install .
-RUN pip3 install -e git+https://github.com/colcon/colcon-ros-bundle.git#0.0.9#egg=colcon-ros-bundle
+RUN pip3 install -e git+https://github.com/colcon/colcon-core.git@master#egg=colcon-core
+RUN pip3 install -e git+https://github.com/colcon/colcon-ros-bundle.git@master#egg=colcon-ros-bundle
 
 WORKDIR /opt/package/integration/test_workspace
 RUN source /opt/ros/kinetic/setup.sh; colcon build

--- a/colcon_bundle/__init__.py
+++ b/colcon_bundle/__init__.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = '0.0.10'
+__version__ = '0.0.11'

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ keywords = colcon
 python_requires = >=3.5
 install_requires =
   colcon-core>=0.3.15
-  colcon-python-setup-py==0.2.1
+  colcon-python-setup-py>=0.2.1
   setuptools>=30.3.0
   distro>=1.3.0
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 [options]
 python_requires = >=3.5
 install_requires =
-  colcon-core==0.3.15
+  colcon-core>=0.3.15
   colcon-python-setup-py==0.2.1
   setuptools>=30.3.0
   distro>=1.3.0

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -6,4 +6,4 @@ import colcon_bundle
 
 def test_version():
     version = colcon_bundle.__version__
-    assert version == '0.0.10'
+    assert version == '0.0.11'


### PR DESCRIPTION
If we don't fix this then customers get this error when they have colcon-core of a later version:

```
Starting >>> deepracer_msgs
]0;colcon build [0/4 done] [1 ongoing]Starting >>> deepracer_simulation
]0;colcon build [0/4 done] [2 ongoing]Finished <<< deepracer_simulation [11.0s]
]0;colcon build [1/4 done] [1 ongoing]Starting >>> sagemaker_rl_agent
]0;colcon build [1/4 done] [2 ongoing]Finished <<< sagemaker_rl_agent [1.31s]
]0;colcon build [2/4 done] [1 ongoing]Finished <<< deepracer_msgs [12.5s]
]0;colcon build [3/4 done] [0 ongoing]Starting >>> deepracer_interpreter
]0;colcon build [3/4 done] [1 ongoing]Finished <<< deepracer_interpreter [23.6s]
]0;colcon build [4/4 done] [0 ongoing]
Summary: 4 packages finished [36.7s]
  1 package had stderr output: sagemaker_rl_agent

----------ERROR-------
ERROR:colcon.colcon_core.entry_point:Exception loading extension 'colcon_core.verb.bundle': (colcon-core 0.3.16 (/usr/local/lib/python3.5/dist-packages), Requirement.parse('colcon-core==0.3.15'))
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/colcon_core/entry_point.py", line 98, in load_entry_points
    extension_type = load_entry_point(entry_point)
  File "/usr/local/lib/python3.5/dist-packages/colcon_core/entry_point.py", line 140, in load_entry_point
    return entry_point.load()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2410, in load
    self.require(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2433, in require
    items = working_set.resolve(reqs, env, installer, extras=self.extras)
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.VersionConflict: (colcon-core 0.3.16 (/usr/local/lib/python3.5/dist-packages), Requirement.parse('colcon-core==0.3.15'))

--- stderr: sagemaker_rl_agent
zip_safe flag not set; analyzing archive contents...
markov.__pycache__.single_machine_training_worker.cpython-35: module references __file__
---
ERROR:colcon.colcon_core.entry_point:Exception loading extension 'colcon_core.verb.bundle': (colcon-core 0.3.16 (/usr/local/lib/python3.5/dist-packages), Requirement.parse('colcon-core==0.3.15'))
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/colcon_core/entry_point.py", line 98, in load_entry_points
    extension_type = load_entry_point(entry_point)
  File "/usr/local/lib/python3.5/dist-packages/colcon_core/entry_point
---Error truncated----
```