### PR TITLE
Add project urls to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,9 @@ author = Matthew Murphy
 author_email = matmur@amazon.com
 maintainer = Matthew Murphy
 maintainer_email = matmur@amazon.com
+project_urls =
+    Changelog = https://github.com/colcon/colcon-bundle/milestones?direction=desc&sort=due_date&state=closed
+    GitHub = https://github.com/colcon/colcon-bundle/
 classifiers =
   Development Status :: 3 - Alpha
   Environment :: Console


### PR DESCRIPTION
Following Dirk's lead on the changelog:

https://github.com/colcon/colcon-core/blob/master/setup.cfg#L5
https://github.com/colcon/colcon.readthedocs.org/pull/42/files