### PR TITLE
Add dependency hash check during bundling

### DIFF
--- a/colcon_bundle/verb/_archive_generators.py
+++ b/colcon_bundle/verb/_archive_generators.py
@@ -132,6 +132,14 @@ def generate_archive_v2(install_base,
                                dependencies_staging_path,
                                mode='w:gz')
 
+    # Update dependencies hash
+    dependency_hash_path = os.path.join(
+        bundle_base, 'dependency_hash.json')
+    dependency_hash_cache_path = os.path.join(
+        bundle_base, 'dependency_hash_cache.json')
+    if os.path.exists(dependency_hash_cache_path):
+        os.replace(dependency_hash_cache_path, dependency_hash_path)
+
     with Bundle(name=archive_tar_path) as bundle:
         for path in metadata_paths:
             bundle.add_metadata(path)

--- a/colcon_bundle/verb/_archive_generators.py
+++ b/colcon_bundle/verb/_archive_generators.py
@@ -6,7 +6,7 @@ from colcon_bundle.verb import logger
 from colcon_bundle.verb.bundlefile import Bundle
 
 
-def generate_archive_v1(bundle_path):
+def generate_archive_v1(path_context):
     """
     Generate bundle archive.
 
@@ -15,12 +15,12 @@ def generate_archive_v1(bundle_path):
     |- metadata.tar
     |- bundle.tar
 
-    :param bundle_path: BundlePath object including path configurations
+    :param path_context: PathContext object including path configurations
     """
     # install_base: Directory with built artifacts from the workspace
-    install_base = bundle_path.install_base()
+    install_base = path_context.install_base()
     # staging_path: Directory where all dependencies have been installed
-    staging_path = bundle_path.staging_path()
+    staging_path = path_context.staging_path()
 
     logger.info('Copying {} into bundle...'.format(install_base))
     assets_directory = os.path.join(
@@ -36,12 +36,12 @@ def generate_archive_v1(bundle_path):
     logger.info('Archiving the bundle output')
     print('Creating bundle archive...')
 
-    bundle_tar_path = bundle_path.bundle_tar_path()
-    metadata_tar_path = bundle_path.metadata_tar_path()
-    archive_tar_gz_path = bundle_path.archive_tar_gz_path()
+    bundle_tar_path = path_context.bundle_tar_path()
+    metadata_tar_path = path_context.metadata_tar_path()
+    archive_tar_gz_path = path_context.archive_tar_gz_path()
 
     with tarfile.open(metadata_tar_path, 'w') as archive:
-        archive.add(bundle_path.installer_metadata_path(),
+        archive.add(path_context.installer_metadata_path(),
                     arcname='installers.json')
 
     if os.path.exists(bundle_tar_path):
@@ -49,7 +49,7 @@ def generate_archive_v1(bundle_path):
 
     _recursive_tar_in_path(bundle_tar_path, staging_path)
 
-    version_file_path = bundle_path.version_file_path()
+    version_file_path = path_context.version_file_path()
     with open(version_file_path, 'w') as v:
         v.write('1')
 
@@ -68,7 +68,7 @@ def generate_archive_v1(bundle_path):
     logger.info('Archiving complete')
 
 
-def generate_archive_v2(bundle_path,
+def generate_archive_v2(path_context,
                         metadata_paths,
                         dependencies_changed):
     """
@@ -83,7 +83,7 @@ def generate_archive_v2(bundle_path,
     |- dependencies.tar.gz
     |- workspace.tar.gz
 
-    :param bundle_path: BundlePath object including all path configurations
+    :param path_context: PathContext object including all path configurations
     :param metadata_paths: [str] paths to files which should be included
     in the metadata archive
     :param dependencies_changed: Boolean representing whether the staging path
@@ -92,11 +92,11 @@ def generate_archive_v2(bundle_path,
     logger.info('Archiving the bundle output')
     print('Creating bundle archive V2...')
 
-    archive_tar_path = bundle_path.archive_tar_path()
-    workspace_tar_gz_path = bundle_path.workspace_tar_gz_path()
+    archive_tar_path = path_context.archive_tar_path()
+    workspace_tar_gz_path = path_context.workspace_tar_gz_path()
 
     # Install directory
-    workspace_staging_path = bundle_path.workspace_staging_path()
+    workspace_staging_path = path_context.workspace_staging_path()
     workspace_install_path = os.path.join(
         workspace_staging_path, 'opt', 'built_workspace')
     shutil.rmtree(workspace_staging_path, ignore_errors=True)
@@ -106,7 +106,7 @@ def generate_archive_v2(bundle_path,
     shellscript_path = os.path.join(assets_directory, 'v2_workspace_setup.sh')
 
     # install_base: Directory with built artifacts from the workspace
-    install_base = bundle_path.install_base()
+    install_base = path_context.install_base()
     os.mkdir(workspace_staging_path)
     shutil.copy2(shellscript_path,
                  os.path.join(workspace_staging_path, 'setup.sh'))
@@ -115,11 +115,11 @@ def generate_archive_v2(bundle_path,
                            mode='w:gz')
 
     # Dependencies directory
-    dependencies_tar_gz_path = bundle_path.dependencies_tar_gz_path()
+    dependencies_tar_gz_path = path_context.dependencies_tar_gz_path()
 
     # dependencies_staging_path: Directory where all dependencies
     # have been installed
-    dependencies_staging_path = bundle_path.staging_path()
+    dependencies_staging_path = path_context.staging_path()
     if dependencies_changed:
         logger.info('Dependencies changed, updating {}'.format(
             dependencies_tar_gz_path
@@ -136,8 +136,8 @@ def generate_archive_v2(bundle_path,
                                mode='w:gz')
 
     # Update dependencies hash
-    dependency_hash_path = bundle_path.dependency_hash_path()
-    dependency_hash_cache_path = bundle_path.dependency_hash_cache_path()
+    dependency_hash_path = path_context.dependency_hash_path()
+    dependency_hash_cache_path = path_context.dependency_hash_cache_path()
     if os.path.exists(dependency_hash_cache_path):
         os.replace(dependency_hash_cache_path, dependency_hash_path)
 

--- a/colcon_bundle/verb/bundle.py
+++ b/colcon_bundle/verb/bundle.py
@@ -93,9 +93,9 @@ class BundleVerb(VerbExtensionPoint):
             '--bundle-version', default=1, type=int,
             help='Version of bundle to generate')
         parser.add_argument(
-            '--upgrade-dependency-graph', action='store_true',
-            help='Upgrade all dependencies in dependency graph (transitive'
-                 ' closure) to newest versions if possible'
+            '-U', '--upgrade', action='store_true',
+            help='Upgrade all dependencies in the bundle to their latest '
+                 'versions'
         )
 
         add_executor_arguments(parser)
@@ -109,7 +109,7 @@ class BundleVerb(VerbExtensionPoint):
 
     def main(self, *, context):  # noqa: D102
         print('Bundling workspace...')
-        upgrade_deps_graph = context.args.upgrade_dependency_graph
+        upgrade_deps_graph = context.args.upgrade
         install_base = os.path.abspath(context.args.install_base)
         bundle_base = os.path.abspath(context.args.bundle_base)
 

--- a/colcon_bundle/verb/bundlepath.py
+++ b/colcon_bundle/verb/bundlepath.py
@@ -1,0 +1,81 @@
+import os
+
+
+class BundlePath:
+    """Provides path configuration for bundle."""
+
+    def __init__(self, bundle_base, install_base):
+        """
+        Constructor.
+
+        :param bundle_base: Directory to place the output of the bundle
+        :param install_base: Directory with built artifacts from the workspace
+        """
+        self._bundle_base = bundle_base
+        self._install_base = install_base
+
+    def bundle_base(self):  # noqa: D400
+        """:return: Directory to place the output of the bundle"""
+        return self._bundle_base
+
+    def install_base(self):  # noqa: D400
+        """:return: Directory with built artifacts from the workspace"""
+        return self._install_base
+
+    def staging_path(self):  # noqa: D400
+        """:return: Directory where all dependencies have been installed"""
+        return os.path.join(self._bundle_base, 'bundle_staging')
+
+    def dependencies_tar_gz_path(self):  # noqa: D400
+        """:return: File path for dependencies tarball"""
+        return os.path.join(self._bundle_base, 'dependencies.tar.gz')
+
+    def installer_metadata_path(self):  # noqa: D400
+        """:return: File path for installer metadata"""
+        return os.path.join(self._bundle_base, 'installer_metadata.json')
+
+    def sources_tar_gz_path(self):  # noqa: D400
+        """:return: File path for sources files tarball"""
+        return os.path.join(self._bundle_base, 'sources.tar.gz')
+
+    def installer_cache_path(self):  # noqa: D400
+        """:return: Directory with installer artifacts from the installation"""
+        return os.path.join(self._bundle_base, 'installer_cache')
+
+    # For archive generation v1
+    def bundle_tar_path(self):  # noqa: D400
+        """:return: File path for bundle tarball for archive v1"""
+        return os.path.join(self._bundle_base, 'bundle.tar')
+
+    def metadata_tar_path(self):  # noqa: D400
+        """:return: File path for metadata tarball for archive v1"""
+        return os.path.join(self._bundle_base, 'metadata.tar')
+
+    def archive_tar_gz_path(self):  # noqa: D400
+        """:return: File path for final output of the bundle for archive v1"""
+        return os.path.join(self._bundle_base, 'output.tar.gz')
+
+    def version_file_path(self):  # noqa: D400
+        """:return: File path for version file for archive v1"""
+        return os.path.join(self._bundle_base, 'version')
+
+    # For archive generation v2
+    def workspace_staging_path(self):  # noqa: D400
+        """:return: Directory where all workspace files locates"""
+        return os.path.join(self._bundle_base, 'workspace_staging')
+
+    def archive_tar_path(self):  # noqa: D400
+        """:return: File path for final output of the bundle for archive v2"""
+        return os.path.join(self._bundle_base, 'output.tar')
+
+    def workspace_tar_gz_path(self):  # noqa: D400
+        """:return: File path for workspace tarball"""
+        return os.path.join(self._bundle_base, 'workspace.tar.gz')
+
+    def dependency_hash_path(self):  # noqa: D400
+        """:return: File path for direct dependency hash"""
+        return os.path.join(self._bundle_base, 'dependency_hash.json')
+
+    def dependency_hash_cache_path(self):  # noqa: D400
+        """:return: File path for direct dependency hash cache"""
+        return os.path.join(self._bundle_base, 'dependency_hash_cache.json')

--- a/colcon_bundle/verb/pathcontext.py
+++ b/colcon_bundle/verb/pathcontext.py
@@ -1,7 +1,7 @@
 import os
 
 
-class BundlePath:
+class PathContext:
     """Provides path configuration for bundle."""
 
     def __init__(self, bundle_base, install_base):


### PR DESCRIPTION
Add dependency hash check during bundling and save bundle time if dependencies have not changed.

**Testing**
pytest unittest
integration test
functional test:
1. build v2 bundle against test_workspace for the first time (~15 minutes)
1. build again and it takes 40 seconds to build since the hash matches
1. change the order of the dependencies in the package.xml, build again, and it takes the same 40 seconds since the hash matches
1. add 'roscpp' as exec dependency in the test-cmake/package.xml and build. Hash mismatch and it takes 4 minutes to build
1. build again and it takes 40 seconds since hash matches 


New commit: [e899841](https://github.com/colcon/colcon-bundle/commit/e899841e43a5fb08d19e9667759a258abecfb007)

1. Check dependencies.tar.gz existence before checking dependencies hash to avoid error
2. Add --upgrade to force check for version upgrades

Testing:

1. With existing dependencies.tar.gz and metadata files, bundling without '--upgrade' will only check package dependencies and bundling from dependencies.tar.gz
2. With existing dependencies.tar.gz and metadata files, bundling with '--upgrade' will check package dependencies and installer dependencies
3. With existing dependencies.tar.gz and metadata files, add new package in package.xml, bundling without '--upgrade' will only check package dependencies and bundling from dependencies.tar.gz
4. With existing dependencies.tar.gz and metadata files, add new package in package.xml, bundling with '--upgrade' will check package dependencies and installer dependencies, and rebuild the dependencies.tar.gz
5. Remove dependencies.tar.gz, bundling will check package dependencies and installer dependencies (which will also do the package install), and rebuild dependencies.tar.gz