### PR TITLE
Do not look for version number on editable pip packages

### DIFF
--- a/colcon_bundle/installer/assets/xenial.sources.list
+++ b/colcon_bundle/installer/assets/xenial.sources.list
@@ -22,3 +22,6 @@ deb-src http://us.archive.ubuntu.com/ubuntu/ xenial-security main restricted uni
 # ROS
 deb http://packages.ros.org/ros/ubuntu xenial main
 
+# OSR Foundation - Gazebo
+deb http://packages.osrfoundation.org/gazebo/ubuntu-stable xenial main
+

--- a/colcon_bundle/installer/base_pip_installer.py
+++ b/colcon_bundle/installer/base_pip_installer.py
@@ -111,4 +111,9 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
     def split_package_version(package_version):
         """Split package==3.2.3 pip freeze output."""
         split_string = package_version.split('==')
+        if len(split_string) < 2 and '-e' in package_version:
+            # Package is installed with --editable flag, and formatted differently. Does not have a version number.
+            # format: -e git+https://<repo>@<commit_hash>#egg=<package_name>.
+            split_string = package_version.split('=')
+            return {'name': split_string[1]}
         return {'name': split_string[0], 'version': split_string[1]}

--- a/colcon_bundle/installer/base_pip_installer.py
+++ b/colcon_bundle/installer/base_pip_installer.py
@@ -111,7 +111,7 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
     def split_package_version(package_version):
         """Split package==3.2.3 pip freeze output."""
         split_string = package_version.split('==')
-        # TODO: This shouldn't be necessary if we fix #40 since we 
+        # TODO: This shouldn't be necessary if we fix #40 since we
         # should never install packages as editable
         if len(split_string) < 2 and '-e' in package_version:
             # Package is installed with --editable flag, and formatted

--- a/colcon_bundle/installer/base_pip_installer.py
+++ b/colcon_bundle/installer/base_pip_installer.py
@@ -112,7 +112,8 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
         """Split package==3.2.3 pip freeze output."""
         split_string = package_version.split('==')
         if len(split_string) < 2 and '-e' in package_version:
-            # Package is installed with --editable flag, and formatted differently. Does not have a version number.
+            # Package is installed with --editable flag, and formatted
+            # differently. Does not have a version number.
             # format: -e git+https://<repo>@<commit_hash>#egg=<package_name>.
             split_string = package_version.split('=')
             return {'name': split_string[1]}

--- a/colcon_bundle/installer/base_pip_installer.py
+++ b/colcon_bundle/installer/base_pip_installer.py
@@ -111,6 +111,8 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
     def split_package_version(package_version):
         """Split package==3.2.3 pip freeze output."""
         split_string = package_version.split('==')
+        # TODO: This shouldn't be necessary if we fix #40 since we 
+        # should never install packages as editable
         if len(split_string) < 2 and '-e' in package_version:
             # Package is installed with --editable flag, and formatted
             # differently. Does not have a version number.


### PR DESCRIPTION
If the user has a local python site and installed editable packages,
they will appear in the output of `pip freeze` in a different format
than other installed packages.

### Testing
Tested on Ubuntu as normal user with an editable copy of `colcon-bundle` installed.  `colcon bundle` succeeds in my catkin workspace.