### PR TITLE
Support Melodic, fix aptitude trusted key config

### DIFF
--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -19,7 +19,7 @@ RUN pip3 install -e .
 
 WORKDIR /opt/package/integration/test_workspace
 RUN source /opt/ros/melodic/setup.sh; colcon build
-RUN source /opt/ros/melodic/setup.sh; colcon bundle --bundle-version 1 --bundle-base v1 --apt-allow-insecure
-RUN source /opt/ros/melodic/setup.sh; colcon bundle --bundle-version 2 --bundle-base v2 --apt-allow-insecure
+RUN source /opt/ros/melodic/setup.sh; colcon bundle --bundle-version 1 --bundle-base v1
+RUN source /opt/ros/melodic/setup.sh; colcon bundle --bundle-version 2 --bundle-base v2
 
 

--- a/colcon_bundle/installer/apt.py
+++ b/colcon_bundle/installer/apt.py
@@ -137,7 +137,12 @@ class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
 
         # Update the cache to the latest, we might not want to do this if the
         # cache already exists?
-        self._cache.update()
+        try:
+            self._cache.update()
+        except apt.cache.FetchFailedException as e:
+            logger.error('Could not fetch from repositories: {}'.format(e))
+            raise RuntimeError('Failed to fetch from repositories. Did '
+                               'you set your keys correctly?')
         self._cache.open()
 
     def is_package_available(self, package_name):  # noqa: D102


### PR DESCRIPTION
Creating the apt cache affects the config values. To find the
correct key paths, we get the value before creating the cache.

```
In [1]: import apt
In [2]: apt.apt_pkg.config.find_file('Dir::Etc::trusted')
Out[2]: '/etc/apt/trusted.gpg'
In [3]: cache = apt.Cache(rootdir='/workspace/aptcache')
In [4]: apt.apt_pkg.config.find_file('Dir::Etc::trusted')
Out[4]: '/workspace/aptcache/etc/apt/trusted.gpg'
```