### PR TITLE
Update ROS2 test to use colcon-ros-bundle master

### DIFF
--- a/Dockerfile.dashing
+++ b/Dockerfile.dashing
@@ -29,7 +29,7 @@ RUN pip3 install --upgrade pip setuptools
 
 RUN pip3 install -U pytest colcon-common-extensions
 ARG CACHE_DATE=not_a_date
-RUN pip3 install git+https://github.com/colcon/colcon-ros-bundle.git@ros2-support
+RUN pip3 install git+https://github.com/colcon/colcon-ros-bundle.git
 RUN pip3 install -e .
 
 WORKDIR /opt/package/integration/ros2_workspace


### PR DESCRIPTION
`colcon-ros-bundle` ROS2 support is pushed, we should use master branch.