### PR TITLE
Support unversioned python dependencies

### DIFF
--- a/colcon_bundle/task/python/bundle.py
+++ b/colcon_bundle/task/python/bundle.py
@@ -33,8 +33,9 @@ class PythonBundleTask(TaskExtensionPoint):
                     'because it is in the workspace'.format_map(locals()))
                 continue
 
-            # Currently, only the first five of these mappings are supported by colcon-core
-            # The others are added for completeness with PEP 440
+            # Currently, only the first five of these mappings are supported
+            # by colcon-core. The others are added for completeness with
+            # PEP 440.
             symbol_mapping = {
                 'version_eq': '==',
                 'version_lte': '<=',

--- a/colcon_bundle/task/python/bundle.py
+++ b/colcon_bundle/task/python/bundle.py
@@ -33,13 +33,17 @@ class PythonBundleTask(TaskExtensionPoint):
                     'because it is in the workspace'.format_map(locals()))
                 continue
 
+            # Currently, only the first five of these mappings are supported by colcon-core
+            # The others are added for completeness with PEP 440
             symbol_mapping = {
                 'version_eq': '==',
-                'version_neq': '!=',
                 'version_lte': '<=',
                 'version_gte': '>=',
                 'version_gt': '>',
                 'version_lt': '<',
+                'version_neq': '!=',
+                'version_aeq': '===',
+                'version_compatible': '~=',
             }
 
             pip = args.installers['pip3']

--- a/colcon_bundle/task/python/bundle.py
+++ b/colcon_bundle/task/python/bundle.py
@@ -42,12 +42,18 @@ class PythonBundleTask(TaskExtensionPoint):
                 'version_lt': '<',
             }
 
+            pip = args.installers['pip3']
+            versioned = False
             for comparator, version in dependency.metadata.items():
                 if symbol_mapping.get(comparator) is not None:
-                    pip = args.installers['pip3']
+                    versioned = True
                     pip.add_to_install_list(
                         dependency.name + symbol_mapping[comparator] + version
                     )
+            if not versioned:
+                pip.add_to_install_list(
+                    dependency.name
+                )
 
             # TODO: The Pip managers should be doing this
             apt = args.installers['apt']


### PR DESCRIPTION
We currently don't install unversioned pip dependencies. We should install them properly as versions are not required.