### PR TITLE
Support the versioning system from apt

### DIFF
--- a/colcon_bundle/installer/apt.py
+++ b/colcon_bundle/installer/apt.py
@@ -13,8 +13,11 @@ from colcon_core.plugin_system import satisfies_version
 
 
 class PackageNotInCacheException(Exception):
-    def __init__(self, package_name):
+    """The requested package was not found in the cache."""
+
+    def __init__(self, package_name):  # noqa: D107
         self.package_name = package_name
+
 
 class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
     """Extension to support apt package manager."""
@@ -161,16 +164,16 @@ class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
         return self._cache[package_key] is not None
 
     def add_to_install_list(self, name, metadata=None):  # noqa: D102
-        logger.info("Adding {name} to install list".format(locals()))
+        logger.info('Adding {name} to install list'.format(name=name))
         package_key, version = self._separate_version_information(name)
         if not self.is_package_available(package_key):
-            logger.error("Package {package_key} is not in the package"
-                         "cache.".format(locals()))
+            logger.error('Package {package_key} is not in the package'
+                         'cache.'.format(package_key=package_key))
             raise PackageNotInCacheException(name)
             return
 
-        logger.info("Found these versions of {package_key}"
-                    .format(locals()))
+        logger.info('Found these versions of {package_key}'
+                    .format(package_key=package_key))
         logger.info(self._cache[package_key].versions)
         if version:
             package = self._cache[package_key]
@@ -178,7 +181,8 @@ class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
             package.candidate = candidate
             package.mark_install(auto_fix=False, from_user=False)
         else:
-            self._cache[package_key].mark_install(auto_fix=False, from_user=False)
+            self._cache[package_key].mark_install(
+                auto_fix=False, from_user=False)
 
     def remove_from_install_list(self, name, metadata=None):  # noqa: D102
         name, _ = self._separate_version_information(name)

--- a/colcon_bundle/installer/apt.py
+++ b/colcon_bundle/installer/apt.py
@@ -175,14 +175,12 @@ class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
         logger.info('Found these versions of {package_key}'
                     .format(package_key=package_key))
         logger.info(self._cache[package_key].versions)
+
+        package = self._cache[package_key]
         if version:
-            package = self._cache[package_key]
             candidate = package.versions.get(package.versions[version])
             package.candidate = candidate
-            package.mark_install(auto_fix=False, from_user=False)
-        else:
-            self._cache[package_key].mark_install(
-                auto_fix=False, from_user=False)
+        package.mark_install(auto_fix=False, from_user=False)
 
     def remove_from_install_list(self, name, metadata=None):  # noqa: D102
         name, _ = self._separate_version_information(name)

--- a/colcon_bundle/installer/apt.py
+++ b/colcon_bundle/installer/apt.py
@@ -176,6 +176,8 @@ class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
         logger.info(self._cache[package_key].versions)
 
         package = self._cache[package_key]
+        # This will fallback to the latest version available
+        # if the specified version does not exist.
         candidate = package.versions.get(version, package.candidate)
         package.candidate = candidate
         package.mark_install(auto_fix=False, from_user=False)

--- a/colcon_bundle/installer/apt.py
+++ b/colcon_bundle/installer/apt.py
@@ -12,6 +12,10 @@ from colcon_bundle.verb.utilities import get_ubuntu_distribution_version
 from colcon_core.plugin_system import satisfies_version
 
 
+class PackageNotInCacheException(Exception):
+    def __init__(self, package_name):
+        self.package_name = package_name
+
 class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
     """Extension to support apt package manager."""
 
@@ -89,6 +93,8 @@ class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
         self.setup()
 
     def setup(self):  # noqa: D102
+        # Importing apt here allows us to run
+        # unit tests on OSX
         import apt
 
         # Get config values before creating cache, as the cache changes
@@ -151,22 +157,28 @@ class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
         return package_name.split('=', maxsplit=1)
 
     def is_package_available(self, package_name):  # noqa: D102
-        package_name, _ = self._separate_version_information(package_name)
-        return self._cache[package_name] is not None
+        package_key, _ = self._separate_version_information(package_name)
+        return self._cache[package_key] is not None
 
     def add_to_install_list(self, name, metadata=None):  # noqa: D102
-        name, version = self._separate_version_information(name)
-        logger.info(
-            'Marking {name} for installation'.format_map(locals()))
-        logger.info(self._cache[name].versions)
+        logger.info("Adding {name} to install list".format(locals()))
+        package_key, version = self._separate_version_information(name)
+        if not self.is_package_available(package_key):
+            logger.error("Package {package_key} is not in the package"
+                         "cache.".format(locals()))
+            raise PackageNotInCacheException(name)
+            return
 
+        logger.info("Found these versions of {package_key}"
+                    .format(locals()))
+        logger.info(self._cache[package_key].versions)
         if version:
-            package = self._cache[name]
+            package = self._cache[package_key]
             candidate = package.versions.get(package.versions[version])
             package.candidate = candidate
             package.mark_install(auto_fix=False, from_user=False)
         else:
-            self._cache[name].mark_install(auto_fix=False, from_user=False)
+            self._cache[package_key].mark_install(auto_fix=False, from_user=False)
 
     def remove_from_install_list(self, name, metadata=None):  # noqa: D102
         name, _ = self._separate_version_information(name)

--- a/colcon_bundle/installer/apt.py
+++ b/colcon_bundle/installer/apt.py
@@ -170,16 +170,14 @@ class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
             logger.error('Package {package_key} is not in the package'
                          'cache.'.format(package_key=package_key))
             raise PackageNotInCacheException(name)
-            return
 
         logger.info('Found these versions of {package_key}'
                     .format(package_key=package_key))
         logger.info(self._cache[package_key].versions)
 
         package = self._cache[package_key]
-        if version:
-            candidate = package.versions.get(package.versions[version])
-            package.candidate = candidate
+        candidate = package.versions.get(version, package.candidate)
+        package.candidate = candidate
         package.mark_install(auto_fix=False, from_user=False)
 
     def remove_from_install_list(self, name, metadata=None):  # noqa: D102

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,0 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0

--- a/test/installer/test_apt_installer.py
+++ b/test/installer/test_apt_installer.py
@@ -1,19 +1,17 @@
+import os
+import shutil
 import sys
+from tempfile import mkdtemp, mkstemp
 from unittest import mock
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from colcon_bundle.installer.apt import AptBundleInstallerExtension
+from colcon_bundle.installer import BundleInstallerContext
 
 
 class AptInstallerTests(unittest.TestCase):
-    def setUp(self):
-        self.tmp_apt = sys.modules.get('apt', None)
-    
-    def tearDown(self):
-        sys.modules['apt'] = self.tmp_apt
-
     @patch('colcon_bundle.installer.apt.get_ubuntu_distribution_version')
     def test_should_load_not_on_ubuntu(self, get_version):
         apt = AptBundleInstallerExtension()
@@ -22,13 +20,46 @@ class AptInstallerTests(unittest.TestCase):
 
     @patch('colcon_bundle.installer.apt.get_ubuntu_distribution_version')
     def test_should_load_on_ubuntu(self, _):
-        sys.modules['apt'] = mock.MagicMock()
-        apt = AptBundleInstallerExtension()
-        assert apt.should_load() == True
+        with patch.dict("sys.modules", apt=mock.MagicMock()):
+            apt = AptBundleInstallerExtension()
+            assert apt.should_load() == True
 
     @patch('colcon_bundle.installer.apt.get_ubuntu_distribution_version')
     def test_should_load_on_ubuntu_no_python3_apt(self, _):
-        sys.modules['apt'] = None
-        apt = AptBundleInstallerExtension()
-        with self.assertRaises(RuntimeError): apt.should_load()
+        with patch.dict("sys.modules", apt=None):
+            apt = AptBundleInstallerExtension()
+            with self.assertRaises(RuntimeError): apt.should_load()
 
+    def test_apt_add_to_install_list_splits_version_specifier(self):
+        # We import apt inside the method it is used so we can't @patch it like
+        # a normal import
+        apt = mock.MagicMock()
+        with patch.dict("sys.modules", apt=apt):
+            package_name = "foo"
+            package_version = "1.3.4"
+            cache_dir = mkdtemp()
+            prefix = mkdtemp()
+            _, sources_list = mkstemp()
+            try:
+                context_args = Mock()
+                context_args.apt_sources_list = sources_list
+                context = BundleInstallerContext(args=context_args, cache_path=cache_dir, prefix_path=prefix)
+                installer = AptBundleInstallerExtension()
+
+                installer.initialize(context)
+
+                package_mock = mock.MagicMock()
+                apt.Cache().__getitem__.return_value = package_mock
+                candidate_mock = mock.MagicMock()
+                package_mock.versions.get.return_value = candidate_mock
+
+                installer.add_to_install_list(package_name + "=" + package_version)
+
+                apt.Cache().__getitem__.assert_called_with(package_name)
+                package_mock.versions.get.assert_called_with(package_mock.versions[package_version])
+                self.assertEqual(package_mock.candidate, candidate_mock)
+                package_mock.mark_install.assert_called_with(auto_fix=False, from_user=False)
+            finally:
+                shutil.rmtree(cache_dir)
+                shutil.rmtree(prefix)
+                os.remove(sources_list)

--- a/test/installer/test_apt_installer.py
+++ b/test/installer/test_apt_installer.py
@@ -49,6 +49,7 @@ class AptInstallerTests(unittest.TestCase):
                 installer.initialize(context)
 
                 package_mock = mock.MagicMock()
+                default_candidate = package_mock.candidate
                 apt.Cache().__getitem__.return_value = package_mock
                 candidate_mock = mock.MagicMock()
                 package_mock.versions.get.return_value = candidate_mock
@@ -56,7 +57,7 @@ class AptInstallerTests(unittest.TestCase):
                 installer.add_to_install_list(package_name + "=" + package_version)
 
                 apt.Cache().__getitem__.assert_called_with(package_name)
-                package_mock.versions.get.assert_called_with(package_mock.versions[package_version])
+                package_mock.versions.get.assert_called_with(package_version, default_candidate)
                 self.assertEqual(package_mock.candidate, candidate_mock)
                 package_mock.mark_install.assert_called_with(auto_fix=False, from_user=False)
             finally:
@@ -82,13 +83,15 @@ class AptInstallerTests(unittest.TestCase):
                 installer.initialize(context)
 
                 package_mock = mock.MagicMock()
+                default_candidate = package_mock.candidate
                 apt.Cache().__getitem__.return_value = package_mock
-                candidate_mock = mock.MagicMock()
-                package_mock.versions.get.return_value = candidate_mock
+                package_mock.versions.get.return_value = default_candidate
 
                 installer.add_to_install_list(package_name)
 
                 apt.Cache().__getitem__.assert_called_with(package_name)
+                package_mock.versions.get.assert_called_with('', default_candidate)
+                self.assertEqual(package_mock.candidate, default_candidate)
                 package_mock.mark_install.assert_called_with(auto_fix=False, from_user=False)
             finally:
                 shutil.rmtree(cache_dir)


### PR DESCRIPTION
As apt is capable of using versions of packages, it would be great to have the same capability in colcon. Just as you could install any apt package by "apt install <package>=<version>", this could be defined in a corresponding rosdep.yaml  and therefore here as well. 