### PR TITLE
Limit setuptools to version 44

### DIFF
--- a/colcon_bundle/installer/base_pip_installer.py
+++ b/colcon_bundle/installer/base_pip_installer.py
@@ -83,7 +83,7 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
 
         python_pip_args = [self._python_path, '-m', 'pip']
         pip_install_args = python_pip_args + ['install']
-        subprocess.check_call(pip_install_args + ['-U', 'pip', 'setuptools'])
+        subprocess.check_call(pip_install_args + ['-U', 'pip', 'setuptools==44.0.0'])
 
         with open(requirements_file, 'w') as req:
             for name in self._packages:

--- a/colcon_bundle/installer/base_pip_installer.py
+++ b/colcon_bundle/installer/base_pip_installer.py
@@ -83,7 +83,8 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
 
         python_pip_args = [self._python_path, '-m', 'pip']
         pip_install_args = python_pip_args + ['install']
-        subprocess.check_call(pip_install_args + ['-U', 'pip', 'setuptools==44.0.0'])
+        subprocess.check_call(
+            pip_install_args + ['-U', 'pip', 'setuptools==44.0.0'])
 
         with open(requirements_file, 'w') as req:
             for name in self._packages:

--- a/test/installer/test_pip3_installer.py
+++ b/test/installer/test_pip3_installer.py
@@ -45,7 +45,8 @@ def test_install(check_output, check_call):
         args = args_list[0][0][0]
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
-        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+        assert args[1:] == [
+            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -95,7 +96,8 @@ def test_install_with_additional_arguments(check_output, check_call):
         args = args_list[0][0][0]
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
-        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+        assert args[1:] == [
+            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -147,7 +149,8 @@ def test_install_not_required(check_output, check_call):
         args = args_list[0][0][0]
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
-        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+        assert args[1:] == [
+            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -213,7 +216,8 @@ def test_install_additional_requirements(check_output, check_call):
         args = args_list[0][0][0]
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
-        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+        assert args[1:] == [
+            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path

--- a/test/installer/test_pip_installer.py
+++ b/test/installer/test_pip_installer.py
@@ -45,7 +45,8 @@ def test_install(check_output, check_call):
         args = args_list[0][0][0]
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
-        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+        assert args[1:] == [
+            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -95,7 +96,8 @@ def test_install_with_additional_arguments(check_output, check_call):
         args = args_list[0][0][0]
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
-        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+        assert args[1:] == [
+            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -146,7 +148,8 @@ def test_install_not_required(check_output, check_call):
         args = args_list[0][0][0]
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
-        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+        assert args[1:] == [
+            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -212,7 +215,8 @@ def test_install_addtional_requirements(check_output, check_call):
         args = args_list[0][0][0]
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
-        assert args[1:] == ['-m', 'pip', 'install', '-U', 'pip', 'setuptools']
+        assert args[1:] == [
+            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path


### PR DESCRIPTION
From [this issue](https://github.com/pypa/virtualenv/issues/1493) it looks like `setuptools` after version 45 breaks python 2 builds.

Change the pip install to target setup tools version 44 only.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>