### PR TITLE
Port Travis CI to Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,120 @@
+name: Testing workflows for colcon-bundle
+on:
+  pull_request:
+  schedule:
+    - cron: '43 17 * * *'
+
+jobs:
+  tox_unittest:
+    runs-on: ubuntu-16.04
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y enchant
+        pip install tox
+    - name: Run tests
+      env:
+        TOXENV: unittest
+      run: tox
+
+  backwards_compatability_test:
+    runs-on: ubuntu-16.04
+    env:
+      TOXENV: py35-pypi
+      ROS_DISTRO: kinetic
+      TEST: backwards
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+        architecture: x64
+    - name: Install dependencies
+      run: |
+        sudo apt update 
+        sudo apt install -y enchant
+    - name: Install Tox
+      run: pip install tox
+    - name: Run tests
+      run: tox
+
+  double_test:
+    runs-on: ubuntu-18.04
+    env:
+      TOXENV: py35-pypi
+      ROS_DISTRO: melodic
+      TEST: double
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+        architecture: x64
+    - name: Install dependencies
+      run: |
+        sudo apt update 
+        sudo apt install -y enchant
+    - name: Install Tox
+      run: pip install tox
+    - name: Run tests
+      run: tox
+
+  ros1_tests:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        toxenv: [py35-pypi, py35-github]
+        ros_distro: [melodic, kinetic]
+    env:
+      TOXENV: ${{ matrix.toxenv }}
+      ROS_DISTRO: ${{ matrix.ros_distro }}
+      TEST: backwards
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+        architecture: x64
+    - name: Install dependencies
+      run: |
+        sudo apt update 
+        sudo apt install -y enchant
+    - name: Install Tox
+      run: pip install tox
+    - name: Run tests
+      run: tox
+
+  ros2_tests:
+    runs-on: ubuntu-18.04
+    env: 
+      TOXENV: py35-pypi
+      ROS_DISTRO: dashing
+      TEST: create
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.5
+          architecture: x64
+      - name: Install dependencies
+        run: |
+          sudo apt update 
+          sudo apt install -y enchant
+      - name: Install Tox
+        run: pip install tox
+      - name: Run tests
+        run: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,9 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update && sudo apt install -y enchant
-        pip install tox
+        pip install -U tox setuptools
     - name: Run tests
-      env:
-        TOXENV: unittest
-      run: tox
+      run: tox -e unittest
 
   backwards_compatability_test:
     runs-on: ubuntu-16.04
@@ -39,7 +37,7 @@ jobs:
         architecture: x64
     - name: Install dependencies
       run: |
-        sudo apt update 
+        sudo apt update
         sudo apt install -y enchant
     - name: Install Tox
       run: pip install tox
@@ -62,7 +60,7 @@ jobs:
         architecture: x64
     - name: Install dependencies
       run: |
-        sudo apt update 
+        sudo apt update
         sudo apt install -y enchant
     - name: Install Tox
       run: pip install tox
@@ -89,7 +87,7 @@ jobs:
         architecture: x64
     - name: Install dependencies
       run: |
-        sudo apt update 
+        sudo apt update
         sudo apt install -y enchant
     - name: Install Tox
       run: pip install tox
@@ -98,7 +96,7 @@ jobs:
 
   ros2_tests:
     runs-on: ubuntu-18.04
-    env: 
+    env:
       TOXENV: py35-pypi
       ROS_DISTRO: dashing
       TEST: create
@@ -112,7 +110,7 @@ jobs:
           architecture: x64
       - name: Install dependencies
         run: |
-          sudo apt update 
+          sudo apt update
           sudo apt install -y enchant
       - name: Install Tox
         run: pip install tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   tox_unittest:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
+    env:
+      TOXENV: unittest
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
@@ -17,12 +19,12 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt update && sudo apt install -y enchant
-        pip install -U tox setuptools
+        pip install -U tox setuptools==44.0.0
     - name: Run tests
-      run: tox -e unittest
+      run: tox
 
   backwards_compatability_test:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
       TOXENV: py35-pypi
       ROS_DISTRO: kinetic
@@ -34,13 +36,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.5
-        architecture: x64
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install -y enchant
-    - name: Install Tox
-      run: pip install tox
+        sudo apt update && sudo apt install -y enchant
+        pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
 
@@ -57,13 +56,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.5
-        architecture: x64
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install -y enchant
-    - name: Install Tox
-      run: pip install tox
+        sudo apt update && sudo apt install -y enchant
+        pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
 
@@ -84,13 +80,10 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.5
-        architecture: x64
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install -y enchant
-    - name: Install Tox
-      run: pip install tox
+        sudo apt update && sudo apt install -y enchant
+        pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
 
@@ -107,12 +100,9 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: 3.5
-          architecture: x64
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install -y enchant
-      - name: Install Tox
-        run: pip install tox
+          sudo apt update && sudo apt install -y enchant
+          pip install -U tox setuptools==44.0.0
       - name: Run tests
         run: tox

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,12 +38,14 @@ Inside of a ROS1 workspace execute the following:
 
 ### Unit
 
-To run tests execute `pytest` in the root directory. Install dependencies using `pip3 install -r requirements_devel.txt`.
-You might need to `apt-get install enchant` to install the spellchecker.
+Prerequisites:
 
-To view stdout from a test while running `pytest` use the `-s` flag.
+```
+pip install tox
+apt-get update && apt-get install enchant
+```
 
-See `.travis.yml` for more information about what runs in the full test suite.
+To run tests execute `tox -e unittest` in the root directory.
 
 ### Integration
 

--- a/run_integration_test.sh
+++ b/run_integration_test.sh
@@ -50,10 +50,10 @@ tar -xzOf ./v1.tar.gz bundle.tar | tar -xf - --directory ./v1_bundle
 # Run tests
 if [[ ${ROS_DISTRO} = "kinetic" ]]
 then
-	docker run -it -v $(pwd):/workspace ubuntu:xenial /workspace/test_v1.sh
-	docker run -it -v $(pwd):/workspace ubuntu:xenial /workspace/test_v2.sh
+	docker run -v $(pwd):/workspace ubuntu:xenial /workspace/test_v1.sh
+	docker run -v $(pwd):/workspace ubuntu:xenial /workspace/test_v2.sh
 else
-	docker run -it -v $(pwd):/workspace ubuntu:bionic /workspace/test_v1.sh
-	docker run -it -v $(pwd):/workspace ubuntu:bionic /workspace/test_v2.sh
+	docker run -v $(pwd):/workspace ubuntu:bionic /workspace/test_v1.sh
+	docker run -v $(pwd):/workspace ubuntu:bionic /workspace/test_v2.sh
 fi
 

--- a/run_ros2_integration_test.sh
+++ b/run_ros2_integration_test.sh
@@ -24,5 +24,5 @@ mkdir ./v2_bundle/workspace
 tar -xOf ./v2.tar workspace.tar.gz | tar -xzf - --directory ./v2_bundle/workspace
 
 # Run tests
-docker run -it -v $(pwd):/workspace ubuntu:bionic /workspace/test_ros2_v2.sh
+docker run -v $(pwd):/workspace ubuntu:bionic /workspace/test_ros2_v2.sh
 


### PR DESCRIPTION
Ports over all the tests from Travis CI to Github Actions.
Runs every morning PST.
Example of this running is in #128.

Addresses ros-security/aws-roadmap#169

`-it` flags were removed because we do not require an interactive terminal for the `docker run` commands and an interactive terminal is not available on the hosts running the GH actions.

The version of `setuptools` was set to `44.0.0` to avoid python2/3 compatibility issues (See #127).

Signed-off-by: Anas Abou Allaban allabana@amazon.com