### PR TITLE
Add sendgrid email step on test failure

### DIFF
--- a/.github/sendgrid.js
+++ b/.github/sendgrid.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+const sgMail = require('@sendgrid/mail');
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+
+const msg = {
+  to: process.env.AWS_ONCALL_PAGE_EMAIL,
+  from: process.env.AWS_ONCALL_EMAIL,
+  subject: `A workflow in ${process.env.GITHUB_REPOSITORY} is failing`,
+  text: `The workflow ${process.env.GITHUB_WORKFLOW} in ${process.env.GITHUB_REPOSITORY} is failing.`,
+  html: `<p>\
+  The workflow ${process.env.GITHUB_WORKFLOW} in \
+  <a href="https://www.github.com/${process.env.GITHUB_REPOSITORY}">${process.env.GITHUB_REPOSITORY}</a> is failing.\
+  </p>`,
+};
+
+sgMail
+  .send(msg)
+  .then(() => console.log('Mail sent successfully'))
+  .catch(error => console.error(error.toString()));

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,11 @@ jobs:
         pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
+    - name: Email on failure
+      if: failure() && github.event == 'schedule'
+      uses: peter-evans/sendgrid-action@v1.0.0
+      env:
+        SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
 
   backwards_compatability_test:
     runs-on: ubuntu-18.04
@@ -42,6 +47,11 @@ jobs:
         pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
+    - name: Email on failure
+      if: failure() && github.event == 'schedule'
+      uses: peter-evans/sendgrid-action@v1.0.0
+      env:
+        SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
 
   double_test:
     runs-on: ubuntu-18.04
@@ -62,6 +72,11 @@ jobs:
         pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
+    - name: Email on failure
+      if: failure() && github.event == 'schedule'
+      uses: peter-evans/sendgrid-action@v1.0.0
+      env:
+        SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
 
   ros1_tests:
     runs-on: ubuntu-18.04
@@ -86,6 +101,11 @@ jobs:
         pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
+    - name: Email on failure
+      if: failure() && github.event == 'schedule'
+      uses: peter-evans/sendgrid-action@v1.0.0
+      env:
+        SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
 
   ros2_tests:
     runs-on: ubuntu-18.04
@@ -106,3 +126,8 @@ jobs:
           pip install -U tox setuptools==44.0.0
       - name: Run tests
         run: tox
+      - name: Email on failure
+        if: failure() && github.event == 'schedule'
+        uses: peter-evans/sendgrid-action@v1.0.0
+        env:
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}


### PR DESCRIPTION
Adds a workflow step that pages the AWS oncall when nightly tests fail.

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>