### PR TITLE
Split workflow into PR and nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,187 @@
+name: Nightly testing workflows for colcon-bundle
+on:
+  schedule:
+    - cron: '43 17 * * *'
+
+jobs:
+  tox_unittest:
+    runs-on: ubuntu-18.04
+    env:
+      TOXENV: unittest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y enchant
+        pip install -U tox setuptools==44.0.0
+    - name: Run tests
+      run: tox
+    - name: Log Test Failure
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+      with:
+        status: 'failure'
+      if: failure() && github.event_name == 'schedule'
+    - name: Log Test Success
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+      with:
+        status: 'success'
+      if: success() && github.event_name == 'schedule'
+
+  backwards_compatability_test:
+    runs-on: ubuntu-18.04
+    env:
+      TOXENV: py35-pypi
+      ROS_DISTRO: kinetic
+      TEST: backwards
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y enchant
+        pip install -U tox setuptools==44.0.0
+    - name: Run tests
+      run: tox
+    - name: Log Test Failure
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+      with:
+        status: 'failure'
+      if: failure() && github.event_name == 'schedule'
+    - name: Log Test Success
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+      with:
+        status: 'success'
+      if: success() && github.event_name == 'schedule'
+
+  double_test:
+    runs-on: ubuntu-18.04
+    env:
+      TOXENV: py35-pypi
+      ROS_DISTRO: melodic
+      TEST: double
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y enchant
+        pip install -U tox setuptools==44.0.0
+    - name: Run tests
+      run: tox
+    - name: Log Test Failure
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+      with:
+        status: 'failure'
+      if: failure() && github.event_name == 'schedule'
+    - name: Log Test Success
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+      with:
+        status: 'success'
+      if: success() && github.event_name == 'schedule'
+
+  ros1_tests:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        toxenv: [py35-pypi, py35-github]
+        ros_distro: [melodic, kinetic]
+    env:
+      TOXENV: ${{ matrix.toxenv }}
+      ROS_DISTRO: ${{ matrix.ros_distro }}
+      TEST: backwards
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+    - name: Setup Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.5
+    - name: Install dependencies
+      run: |
+        sudo apt update && sudo apt install -y enchant
+        pip install -U tox setuptools==44.0.0
+    - name: Run tests
+      run: tox
+    - name: Log Test Failure
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+      with:
+        status: 'failure'
+      if: failure() && github.event_name == 'schedule'
+    - name: Log Test Success
+      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+      with:
+        status: 'success'
+      if: success() && github.event_name == 'schedule'
+
+  ros2_tests:
+    runs-on: ubuntu-18.04
+    env:
+      TOXENV: py35-pypi
+      ROS_DISTRO: dashing
+      TEST: create
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.5
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install -y enchant
+          pip install -U tox setuptools==44.0.0
+      - name: Run tests
+        run: tox
+      - name: Log Test Failure
+        uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+        with:
+          status: 'failure'
+        if: failure() && github.event_name == 'schedule'
+      - name: Log Test Success
+        uses: ros-tooling/action-cloudwatch-metrics@0.0.1
+        with:
+          status: 'success'
+        if: success() && github.event_name == 'schedule'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,12 +33,12 @@ jobs:
       uses: ros-tooling/action-cloudwatch-metrics@0.0.1
       with:
         status: 'failure'
-      if: failure() && github.event_name == 'schedule'
+      if: failure()
     - name: Log Test Success
       uses: ros-tooling/action-cloudwatch-metrics@0.0.1
       with:
         status: 'success'
-      if: success() && github.event_name == 'schedule'
+      if: success()
 
   backwards_compatability_test:
     runs-on: ubuntu-18.04
@@ -69,12 +69,12 @@ jobs:
       uses: ros-tooling/action-cloudwatch-metrics@0.0.1
       with:
         status: 'failure'
-      if: failure() && github.event_name == 'schedule'
+      if: failure()
     - name: Log Test Success
       uses: ros-tooling/action-cloudwatch-metrics@0.0.1
       with:
         status: 'success'
-      if: success() && github.event_name == 'schedule'
+      if: success()
 
   double_test:
     runs-on: ubuntu-18.04
@@ -105,12 +105,12 @@ jobs:
       uses: ros-tooling/action-cloudwatch-metrics@0.0.1
       with:
         status: 'failure'
-      if: failure() && github.event_name == 'schedule'
+      if: failure()
     - name: Log Test Success
       uses: ros-tooling/action-cloudwatch-metrics@0.0.1
       with:
         status: 'success'
-      if: success() && github.event_name == 'schedule'
+      if: success()
 
   ros1_tests:
     runs-on: ubuntu-18.04
@@ -145,12 +145,12 @@ jobs:
       uses: ros-tooling/action-cloudwatch-metrics@0.0.1
       with:
         status: 'failure'
-      if: failure() && github.event_name == 'schedule'
+      if: failure()
     - name: Log Test Success
       uses: ros-tooling/action-cloudwatch-metrics@0.0.1
       with:
         status: 'success'
-      if: success() && github.event_name == 'schedule'
+      if: success()
 
   ros2_tests:
     runs-on: ubuntu-18.04
@@ -181,9 +181,9 @@ jobs:
         uses: ros-tooling/action-cloudwatch-metrics@0.0.1
         with:
           status: 'failure'
-        if: failure() && github.event_name == 'schedule'
+        if: failure()
       - name: Log Test Success
         uses: ros-tooling/action-cloudwatch-metrics@0.0.1
         with:
           status: 'success'
-        if: success() && github.event_name == 'schedule'
+        if: success()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,7 @@
 name: Nightly testing workflows for colcon-bundle
 on:
+  # Build at minute 43 hour 17 (9:43am PST)
+  # Minutes was chosen randomly
   schedule:
     - cron: '43 17 * * *'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
-name: Testing workflows for colcon-bundle
+name: PR testing workflows for colcon-bundle
 on:
   pull_request:
-  schedule:
-    - cron: '43 17 * * *'
 
 jobs:
   tox_unittest:
@@ -12,12 +10,6 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
@@ -28,16 +20,6 @@ jobs:
         pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
-    - name: Log Test Failure
-      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-      with:
-        status: 'failure'
-      if: failure() && github.event_name == 'schedule'
-    - name: Log Test Success
-      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-      with:
-        status: 'success'
-      if: success() && github.event_name == 'schedule'
 
   backwards_compatability_test:
     runs-on: ubuntu-18.04
@@ -48,12 +30,6 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
@@ -64,16 +40,6 @@ jobs:
         pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
-    - name: Log Test Failure
-      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-      with:
-        status: 'failure'
-      if: failure() && github.event_name == 'schedule'
-    - name: Log Test Success
-      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-      with:
-        status: 'success'
-      if: success() && github.event_name == 'schedule'
 
   double_test:
     runs-on: ubuntu-18.04
@@ -84,12 +50,6 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
@@ -100,16 +60,6 @@ jobs:
         pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
-    - name: Log Test Failure
-      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-      with:
-        status: 'failure'
-      if: failure() && github.event_name == 'schedule'
-    - name: Log Test Success
-      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-      with:
-        status: 'success'
-      if: success() && github.event_name == 'schedule'
 
   ros1_tests:
     runs-on: ubuntu-18.04
@@ -124,12 +74,6 @@ jobs:
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
@@ -140,16 +84,6 @@ jobs:
         pip install -U tox setuptools==44.0.0
     - name: Run tests
       run: tox
-    - name: Log Test Failure
-      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-      with:
-        status: 'failure'
-      if: failure() && github.event_name == 'schedule'
-    - name: Log Test Success
-      uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-      with:
-        status: 'success'
-      if: success() && github.event_name == 'schedule'
 
   ros2_tests:
     runs-on: ubuntu-18.04
@@ -160,12 +94,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -176,13 +104,3 @@ jobs:
           pip install -U tox setuptools==44.0.0
       - name: Run tests
         run: tox
-      - name: Log Test Failure
-        uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-        with:
-          status: 'failure'
-        if: failure() && github.event_name == 'schedule'
-      - name: Log Test Success
-        uses: ros-tooling/action-cloudwatch-metrics@0.0.1
-        with:
-          status: 'success'
-        if: success() && github.event_name == 'schedule'


### PR DESCRIPTION
### Changes
* Split GitHub workflow into cron task (paging) and PRs 
* PR tasks skip the AWS credential stage so they should work if ran on forks

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>