### PR TITLE
Only run Configure AWS Credentials on schedule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Configure AWS Credentials
+      if: github.event_name == 'schedule'
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -49,6 +50,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Configure AWS Credentials
+      if: github.event_name == 'schedule'
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -85,6 +87,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Configure AWS Credentials
+      if: github.event_name == 'schedule'
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -125,6 +128,7 @@ jobs:
     - name: Checkout sources
       uses: actions/checkout@v2
     - name: Configure AWS Credentials
+      if: github.event_name == 'schedule'
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -161,6 +165,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Configure AWS Credentials
+        if: github.event_name == 'schedule'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Disable AWS configuration on tasks triggered by PRs.
This will allow PRs ran from forks (that do not include AWS credentials) to run CI.

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>