### PR TITLE
Make shebang update stricter and handle more cases

### DIFF
--- a/colcon_bundle/verb/utilities.py
+++ b/colcon_bundle/verb/utilities.py
@@ -55,9 +55,11 @@ def update_shebang(path):
 
     :param path: Path to directory with files to replace shebang in.
     """
-    # TODO: We should handle scripts that have parameters in the shebang
     # Parse the shebang
-    shebang_regex = re.compile(r'#!\S*.')
+    shebang_regex = re.compile(r'^#!\s*\S*.')
+    # Shebangs in templates are a special case we need to handle.
+    # Example: #!@PYTHON_EXECUTABLE@
+    template_shebang_regex = re.compile(r'^#!\s*@\S*.@')
     # Parse the command to execute in the shebang
     cmd_regex = re.compile(r'([^\/]*)\/*$')
     logger.info('Starting shebang update...')
@@ -72,6 +74,11 @@ def update_shebang(path):
                     try:
                         str_contents = contents.decode()
                     except UnicodeError:
+                        continue
+                    template_shebang_match = template_shebang_regex.match(
+                        str_contents)
+                    if template_shebang_match:
+                        logger.debug('Skipping templated shebang')
                         continue
                     shebang_match = shebang_regex.match(str_contents)
                     if shebang_match:

--- a/test/assets/template_shebang.sh
+++ b/test/assets/template_shebang.sh
@@ -1,3 +1,3 @@
-#! /usr/bin/python
+#!@PYTHON_EXECUTABLE@
 
 # Other contents not changed

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -19,6 +19,7 @@ class TestUtilities:
     def test_replaces_regular_shebang(self):
         shebang_scripts = [
             ('python_shebang.sh', 'python_shebang_expected.sh'),
+            ('template_shebang.sh', 'template_shebang.sh'),
             ('regular_python_shebang.sh', 'regular_python_shebang_expected.sh'),
             ('regular_python3_shebang.sh', 'regular_python3_shebang_expected.sh'),
             ('regular_node_shebang.sh', 'regular_node_shebang_expected.sh')
@@ -37,7 +38,6 @@ class TestUtilities:
             actual_file = os.path.join(self.tmpdir, regular_shebang_script)
             expected_file = os.path.join(assets_directory,
                                          expected_shebang_script)
-            print('test')
             assert filecmp.cmp(actual_file, expected_file), \
                 "{} did not match expected file {}".format(
                   regular_shebang_script, expected_shebang_script)


### PR DESCRIPTION
Make the shebang update stricter and handle new cases with spaces and templates

Examples:

```
#! /usr/bin/python -> #!/usr/bin/env python
#!@PYTHON_EXECUTABLE@ -> #!@PYTHON_EXECUTABLE@ 
```

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>