### PR TITLE
Fix broken test_bundlefile.py for py3.8

### DIFF
--- a/colcon_bundle/verb/bundlefile.py
+++ b/colcon_bundle/verb/bundlefile.py
@@ -1,4 +1,3 @@
-import contextlib
 import json
 import math
 import os
@@ -14,6 +13,9 @@ logger = colcon_logger.getChild(__name__)
 # Size in bytes
 MAX_METADATA_SIZE = 4 * 1024 * 1024
 
+# tarfile format used in bundlefiles
+TARFILE_FORMAT = tarfile.GNU_FORMAT
+
 
 class Bundle:
     """Provides an interface to application bundle files."""
@@ -28,7 +30,7 @@ class Bundle:
         :param name: path to the bundle archive
         :param mode: mode to open file as
         """
-        self.tarfile = tarfile.open(name, mode)
+        self.tarfile = tarfile.open(name, mode, format=TARFILE_FORMAT)
         self.overlays = []
         self.metadata = []
         self.mode = mode
@@ -63,14 +65,14 @@ class Bundle:
             with open(version_path, 'w') as v:
                 v.write('2')
             self.tarfile.add(version_path, arcname='version')
-            logger.debug('Start: metadta')
+            logger.debug('Start: metadata')
             offset = MAX_METADATA_SIZE
             overlay_metadata = []
             for overlay in self.overlays:
                 name = os.path.basename(overlay)
                 checksum = filechecksum(overlay)
                 info = self.tarfile.gettarinfo(overlay, arcname=name)
-                header_size = len(info.tobuf())
+                header_size = len(info.tobuf(TARFILE_FORMAT))
                 file_size = os.stat(overlay).st_size
                 overlay_metadata.append({
                     'name': name,
@@ -118,13 +120,7 @@ class Bundle:
 
     def close(self):  # noqa: N806
         """Close the archive."""
-        # We don't use any magic numbers here
-        # but Python 3.9 is updating to use the
-        # PAX format and we should do thorough
-        # testing before changing the format
-        # we use.
-        with _set_temporary_tarfile_default_format(tarfile.GNU_FORMAT):
-            self._close()
+        self._close()
 
     def _check(self, mode=None):
         """Check if Bundle is still open. And mode is valid."""
@@ -138,13 +134,3 @@ class Bundle:
 
     def __exit__(self, t, value, traceback):  # noqa: D105
         self.close()
-
-
-@contextlib.contextmanager
-def _set_temporary_tarfile_default_format(value):
-    tarfile_format = tarfile.DEFAULT_FORMAT
-    tarfile.DEFAULT_FORMAT = value
-    try:
-        yield
-    finally:
-        tarfile.DEFAULT_FORMAT = tarfile_format

--- a/test/test_bundlefile.py
+++ b/test/test_bundlefile.py
@@ -99,7 +99,7 @@ class TestBundlefile:
             assert actual_data == json_data
 
     def test_bundlefile_metadata_over_4mb(self):
-        file_size = 6 * 1024 * 1024 # size in bytes
+        file_size = 6 * 1024 * 1024  # size in bytes
         large_file_path = os.path.join(self.tmpdir, 'big_file')
         with open(large_file_path, "wb") as f:
             f.write(os.urandom(file_size))
@@ -122,4 +122,3 @@ class TestBundlefile:
                 bundle.add_metadata(large_file_path)
                 bundle.add_overlay_archive(archive)
                 bundle.add_overlay_archive(other)
-


### PR DESCRIPTION
Fixes https://github.com/colcon/colcon-bundle/issues/160

```bash
➜ python3.8 -m pytest -v test/test_bundlefile.py
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.8.2, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3.8
cachedir: .pytest_cache
inifile: setup.cfg
plugins: cov-2.8.1, repeat-0.8.0, rerunfailures-9.0, mock-1.7.1
collected 2 items

test/test_bundlefile.py::TestBundlefile::test_bundlefile PASSED                                                                                                                                                                                        [ 50%]
test/test_bundlefile.py::TestBundlefile::test_bundlefile_metadata_over_4mb PASSED                                                                                                                                                                      [100%]

===================================================================================================================== 2 passed in 0.22s ======================================================================================================================
```

```bash
➜ python3 -m pytest -v test/test_bundlefile.py
##vso[task.logissue type=warning;]The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
Add 'junit_family=legacy' to your pytest.ini file to silence this warning and make your suite compatible.
==================================================================================================================== test session starts =====================================================================================================================
platform linux -- Python 3.6.9, pytest-5.3.2, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
collected 2 items

test_bundlefile PASSED                                                                                                                                                                                                                                 [ 50%]
test_bundlefile_metadata_over_4mb PASSED                                                                                                                                                                                                               [100%]


====================================================================================================================== warnings summary ======================================================================================================================
```

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>