### PR TITLE
Relax the distro requirement from 1.3.0 to 1.2.0

### DIFF
--- a/requirements_devel.txt
+++ b/requirements_devel.txt
@@ -13,4 +13,4 @@ pyenchant
 pylint
 pytest==4.0.0
 pytest-cov
-distro>=1.3.0
+distro>=1.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
   colcon-core>=0.3.15
   colcon-python-setup-py>=0.2.1
   setuptools>=30.3.0
-  distro>=1.3.0
+  distro>=1.2.0
 packages = find:
 tests_require =
   flake8


### PR DESCRIPTION
The `CHANGELOG.md` for `distro` indicates that there were no changes related to Linux between 1.2.0 and 1.3.0.

Moving to 1.2.0 will make the package installable on RHEL 7 with no adverse side effects.

Here is the `distro` changelog: https://github.com/nir0s/distro/blob/v1.3.0/CHANGELOG.md#130-20180509

This dependency was originally introduced by [#21](https://github.com/colcon/colcon-bundle/pull/21/files#diff-e87397d755f3cab2259647c5e8dbdbe4)