### PR TITLE
 Fix support for `--pip-requirements`

### DIFF
--- a/colcon_bundle/installer/apt.py
+++ b/colcon_bundle/installer/apt.py
@@ -160,6 +160,10 @@ class AptBundleInstallerExtension(BundleInstallerExtensionPoint):
         # Workaround for pip-requirements not installing python-pip
         self.add_to_install_list('python3-pip')
 
+        # Currently not available in Focal
+        if get_ubuntu_distribution_version() != 'focal':
+            self.add_to_install_list('python-pip')
+
     def _separate_version_information(self, package_name):
         if '=' not in package_name:
             return package_name, ''


### PR DESCRIPTION
Install python-pip for distros other than focal

Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>