### PR TITLE
Use ubuntu mirrors package for debian sources.list

### DIFF
--- a/colcon_bundle/installer/assets/bionic.sources.list
+++ b/colcon_bundle/installer/assets/bionic.sources.list
@@ -14,10 +14,10 @@ deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ bionic-security mai
 
 # Source Repositories
 
-deb-src http://archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu/ bionic-updates main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu/ bionic-security main restricted universe multiverse
+deb-src mirror://mirrors.ubuntu.com/mirrors.txt bionic main restricted universe multiverse
+deb-src mirror://mirrors.ubuntu.com/mirrors.txt bionic-updates main restricted universe multiverse
+deb-src mirror://mirrors.ubuntu.com/mirrors.txt bionic-backports main restricted universe multiverse
+deb-src mirror://mirrors.ubuntu.com/mirrors.txt bionic-security main restricted universe multiverse
 
 # ROS 1
 deb [arch=amd64,i386,arm64,armhf] http://packages.ros.org/ros/ubuntu bionic main

--- a/colcon_bundle/installer/assets/bionic.sources.list
+++ b/colcon_bundle/installer/assets/bionic.sources.list
@@ -1,8 +1,8 @@
 # x86 Support
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic-updates main restricted universe multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ bionic-security main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt bionic main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt bionic-updates main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt bionic-backports main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt bionic-security main restricted universe multiverse
 
 
 # ARM Support
@@ -14,10 +14,10 @@ deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ bionic-security mai
 
 # Source Repositories
 
-deb-src http://us.archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-updates main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ bionic-security main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ bionic main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ bionic-updates main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ bionic-security main restricted universe multiverse
 
 # ROS 1
 deb [arch=amd64,i386,arm64,armhf] http://packages.ros.org/ros/ubuntu bionic main

--- a/colcon_bundle/installer/assets/focal.sources.list
+++ b/colcon_bundle/installer/assets/focal.sources.list
@@ -1,8 +1,8 @@
 # x86 Support
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt focal main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt focal-updates main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt focal-backports main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt focal-security main restricted universe multiverse
 
 
 # ARM Support
@@ -14,10 +14,10 @@ deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-security main
 
 # Source Repositories
 
-deb-src http://us.archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
 
 # ROS 1
 deb [arch=amd64,i386,arm64,armhf] http://packages.ros.org/ros/ubuntu focal main

--- a/colcon_bundle/installer/assets/focal.sources.list
+++ b/colcon_bundle/installer/assets/focal.sources.list
@@ -14,10 +14,10 @@ deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-security main
 
 # Source Repositories
 
-deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
-deb-src http://archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+deb-src mirror://mirrors.ubuntu.com/mirrors.txt focal main restricted universe multiverse
+deb-src mirror://mirrors.ubuntu.com/mirrors.txt focal-updates main restricted universe multiverse
+deb-src mirror://mirrors.ubuntu.com/mirrors.txt focal-backports main restricted universe multiverse
+deb-src mirror://mirrors.ubuntu.com/mirrors.txt focal-security main restricted universe multiverse
 
 # ROS 1
 deb [arch=amd64,i386,arm64,armhf] http://packages.ros.org/ros/ubuntu focal main

--- a/colcon_bundle/installer/assets/xenial.sources.list
+++ b/colcon_bundle/installer/assets/xenial.sources.list
@@ -1,8 +1,8 @@
 # x86 Support
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
-deb [arch=amd64,i386] http://us.archive.ubuntu.com/ubuntu/ xenial-security main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt xenial main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt xenial-updates main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt xenial-backports main restricted universe multiverse
+deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt xenial-security main restricted universe multiverse
 
 
 # ARM Support
@@ -14,10 +14,10 @@ deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports/ xenial-security mai
 
 # Source Repositories
 
-deb-src http://us.archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
-deb-src http://us.archive.ubuntu.com/ubuntu/ xenial-security main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ xenial-security main restricted universe multiverse
 
 # ROS
 deb http://packages.ros.org/ros/ubuntu xenial main

--- a/colcon_bundle/installer/assets/xenial.sources.list
+++ b/colcon_bundle/installer/assets/xenial.sources.list
@@ -1,8 +1,8 @@
 # x86 Support
-deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt xenial main restricted universe multiverse
-deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt xenial-updates main restricted universe multiverse
-deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt xenial-backports main restricted universe multiverse
-deb [arch=amd64,i386] mirror://mirrors.ubuntu.com/mirrors.txt xenial-security main restricted universe multiverse
+deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/ xenial main restricted universe multiverse
+deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/ xenial-updates main restricted universe multiverse
+deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/ xenial-backports main restricted universe multiverse
+deb [arch=amd64,i386] http://archive.ubuntu.com/ubuntu/ xenial-security main restricted universe multiverse
 
 
 # ARM Support


### PR DESCRIPTION
Use the `mirror` protocol so `apt` selects the best mirror to use for downloading packages.
The default `sources.list` file used by colcon-bundle hardcoded the repo to the US mirror.
`apt` will now select the best mirror based on network and location.

Using the US repo on an instance in Tokyo, `colcon bundle` took 14m 59.416s.
Using the `mirror` protocol, bundling now takes 3m 47.402s

The mirror protocol does not work for Ubuntu Xenial (16.04) so we use the default archive repo instead of the explicit one from the US (which redirects to it's own mirror accordingly).

Signed-off-by: Anas Abou Allaban <allabana@amazon.com>