### PR TITLE
Use distutils workaround for latest setuptools v50

### DIFF
--- a/Dockerfile.backwards
+++ b/Dockerfile.backwards
@@ -13,7 +13,10 @@ RUN apt-get update && \
 RUN	rosdep update && \
 	rosdep install --from-paths integration/test_workspace --ignore-src -r -y
 
-RUN pip3 install --upgrade pip setuptools!=50.0.0
+# NOTE: This is a workaround for setuptools 50.* (see https://github.com/pypa/setuptools/issues/2352)
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
+
+RUN pip3 install --upgrade pip setuptools
 RUN pip3 install -r requirements.txt
 RUN pip3 install colcon-bundle
 

--- a/Dockerfile.dashing
+++ b/Dockerfile.dashing
@@ -27,7 +27,10 @@ RUN mkdir -p /home/builduser
 RUN chown builduser /home/builduser
 RUN sh -c "echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers"
 
-RUN pip3 install --upgrade pip setuptools!=50.0.0
+# NOTE: This is a workaround for setuptools 50.* (see https://github.com/pypa/setuptools/issues/2352)
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
+
+RUN pip3 install --upgrade pip setuptools
 # RUN pip3 install -r requirements.txt
 
 RUN pip3 install -U pytest colcon-common-extensions

--- a/Dockerfile.double
+++ b/Dockerfile.double
@@ -10,10 +10,13 @@ WORKDIR /opt/package
 RUN apt-get update && \
 	apt-get install -y python3-pip python3-apt python-pip enchant sudo
 
+# NOTE: This is a workaround for setuptools 50.* (see https://github.com/pypa/setuptools/issues/2352)
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
+
 RUN	rosdep update && \
 	rosdep install --from-paths integration/test_workspace --ignore-src -r -y
 
-RUN pip3 install --upgrade pip setuptools!=50.0.0
+RUN pip3 install --upgrade pip setuptools
 RUN pip3 install -r requirements.txt
 RUN pip3 install -e .
 

--- a/Dockerfile.kinetic
+++ b/Dockerfile.kinetic
@@ -16,7 +16,7 @@ RUN mkdir -p /home/builduser
 RUN chown builduser /home/builduser
 RUN sh -c "echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers"
 
-RUN pip3 install --upgrade pip setuptools!=50.0.0
+RUN pip3 install --upgrade pip setuptools
 RUN pip3 install -r requirements.txt
 RUN pip3 install -e .
 
@@ -29,6 +29,7 @@ RUN	rosdep update && \
 
 WORKDIR /opt/package/integration/test_workspace
 
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 RUN source /opt/ros/kinetic/setup.sh; colcon build
 RUN source /opt/ros/kinetic/setup.sh; colcon bundle --bundle-version 1 --bundle-base v1 --pip-requirements py27_requirements.txt --pip3-requirements py3_requirements.txt
 RUN source /opt/ros/kinetic/setup.sh; colcon bundle --bundle-version 2 --bundle-base v2 --pip-requirements py27_requirements.txt --pip3-requirements py3_requirements.txt

--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -19,7 +19,7 @@ RUN mkdir -p /home/builduser
 RUN chown builduser /home/builduser
 RUN sh -c "echo 'builduser ALL=NOPASSWD: ALL' >> /etc/sudoers"
 
-RUN pip3 install --upgrade pip setuptools!=50.0.0
+RUN pip3 install --upgrade pip setuptools
 RUN pip3 install -r requirements.txt
 RUN pip3 install -e .
 
@@ -32,6 +32,8 @@ RUN	rosdep update && \
 
 WORKDIR /opt/package/integration/test_workspace
 
+# NOTE: This is a workaround for setuptools 50.* (see https://github.com/pypa/setuptools/issues/2352)
+ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 RUN source /opt/ros/melodic/setup.sh; colcon build
 RUN source /opt/ros/melodic/setup.sh; colcon bundle --bundle-version 1 --bundle-base v1 --pip-requirements py27_requirements.txt --pip3-requirements py3_requirements.txt
 RUN source /opt/ros/melodic/setup.sh; colcon bundle --bundle-version 2 --bundle-base v2 --pip-requirements py27_requirements.txt --pip3-requirements py3_requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.5
 install_requires =
   colcon-core>=0.3.15
   colcon-python-setup-py>=0.2.1
-  setuptools>=30.3.0
+  setuptools>=30.3.0,!=50.0.0
   distro>=1.2.0
 packages = find:
 tests_require =
@@ -76,14 +76,3 @@ junit_suite_name = colcon-bundle
 
 [flake8]
 import-order-style = google
-
-
-
-
-
-
-
-
-
-
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ python_requires = >=3.5
 install_requires =
   colcon-core>=0.3.15
   colcon-python-setup-py>=0.2.1
-  setuptools>=30.3.0,!=50.0.0
+  setuptools>=30.3.0
   distro>=1.2.0
 packages = find:
 tests_require =


### PR DESCRIPTION
The setup.cfg was causing the dockerfile to still install setuptools 50 in `pip3 install colcon-bundle`. I think this line is using the local directory, not pypi, so this should fix CI. Followup to #179 