### PR TITLE
Add perception_pcl to test_bundle.repos to fix integration tests

### DIFF
--- a/.github/workflows/test_bundle.repos
+++ b/.github/workflows/test_bundle.repos
@@ -7,3 +7,8 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation
     version: 0332151fd7628dddce5df1b1e69e1e251b4c4dec
+  perception_pcl:
+    type: git
+    url: https://github.com/ros-perception/perception_pcl
+    version: 539b5a78b2fb0f0004911c8f85d43a3cc0472625
+


### PR DESCRIPTION
The integration tests were failing due to a bug in `perception_pcl` where the library is not at the expected install location, caused by https://github.com/ros-perception/perception_pcl/issues/318.
This change is a workaround that adds `perception_pcl` to the workspace so it builds from source.

The commit pinned for `perception_pcl` is [HEAD of kinetic-devel](https://github.com/ros-perception/perception_pcl/commit/539b5a78b2fb0f0004911c8f85d43a3cc0472625)

Signed-off-by: Zachary Michaels <zacmicha@amazon.com>