### PR TITLE
Add support for ROS1 Noetic and ROS2 Foxy in setup.sh files.

### DIFF
--- a/colcon_bundle/verb/assets/v1_setup.sh
+++ b/colcon_bundle/verb/assets/v1_setup.sh
@@ -13,9 +13,9 @@ elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh ]; then
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/noetic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/noetic . $BUNDLE_CURRENT_PREFIX/opt/ros/noetic/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh ]; then
-  AMENT_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/ros/dashing . $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh
+  _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/dashing . $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/foxy/setup.sh ]; then
-  AMENT_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/ros/foxy . $BUNDLE_CURRENT_PREFIX/opt/ros/foxy/setup.sh
+  _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/foxy . $BUNDLE_CURRENT_PREFIX/opt/ros/foxy/setup.sh
 fi
 
 COLCON_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/install . $BUNDLE_CURRENT_PREFIX/opt/install/setup.sh

--- a/colcon_bundle/verb/assets/v1_setup.sh
+++ b/colcon_bundle/verb/assets/v1_setup.sh
@@ -10,8 +10,12 @@ if [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/kinetic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/kinetic . $BUNDLE_CURRENT_PREFIX/opt/ros/kinetic/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/melodic . $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh
+elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh ]; then
+  _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/noetic . $BUNDLE_CURRENT_PREFIX/opt/ros/noetic/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh ]; then
-  _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/dashing . $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh
+  AMENT_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/ros/dashing . $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh
+elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/foxy/setup.sh ]; then
+  AMENT_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/ros/foxy . $BUNDLE_CURRENT_PREFIX/opt/ros/foxy/setup.sh
 fi
 
 COLCON_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/install . $BUNDLE_CURRENT_PREFIX/opt/install/setup.sh

--- a/colcon_bundle/verb/assets/v1_setup.sh
+++ b/colcon_bundle/verb/assets/v1_setup.sh
@@ -10,7 +10,7 @@ if [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/kinetic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/kinetic . $BUNDLE_CURRENT_PREFIX/opt/ros/kinetic/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/melodic . $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh
-elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh ]; then
+elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/noetic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/noetic . $BUNDLE_CURRENT_PREFIX/opt/ros/noetic/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh ]; then
   AMENT_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/ros/dashing . $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh

--- a/colcon_bundle/verb/assets/v2_setup.sh
+++ b/colcon_bundle/verb/assets/v2_setup.sh
@@ -10,7 +10,7 @@ if [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/kinetic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/kinetic . $BUNDLE_CURRENT_PREFIX/opt/ros/kinetic/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/melodic . $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh
-elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh ]; then
+elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/noetic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/noetic . $BUNDLE_CURRENT_PREFIX/opt/ros/noetic/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh ]; then
   AMENT_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/ros/dashing . $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh

--- a/colcon_bundle/verb/assets/v2_setup.sh
+++ b/colcon_bundle/verb/assets/v2_setup.sh
@@ -10,6 +10,10 @@ if [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/kinetic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/kinetic . $BUNDLE_CURRENT_PREFIX/opt/ros/kinetic/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh ]; then
   _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/melodic . $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh
+elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/melodic/setup.sh ]; then
+  _CATKIN_SETUP_DIR=$BUNDLE_CURRENT_PREFIX/opt/ros/noetic . $BUNDLE_CURRENT_PREFIX/opt/ros/noetic/setup.sh
 elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh ]; then
   AMENT_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/ros/dashing . $BUNDLE_CURRENT_PREFIX/opt/ros/dashing/setup.sh
+elif [ -f $BUNDLE_CURRENT_PREFIX/opt/ros/foxy/setup.sh ]; then
+  AMENT_CURRENT_PREFIX=$BUNDLE_CURRENT_PREFIX/opt/ros/foxy . $BUNDLE_CURRENT_PREFIX/opt/ros/foxy/setup.sh
 fi


### PR DESCRIPTION
Adding paths for ROS1 Noetic and ROS2 Foxy in the setup.sh file that is generated for sourcing the dependency overlay. 