### PR TITLE
Remove workaround for libvtkproj due to fix with new Kinetic release.

### DIFF
--- a/.github/workflows/test_bundle.repos
+++ b/.github/workflows/test_bundle.repos
@@ -7,8 +7,3 @@ repositories:
     type: git
     url: https://github.com/ros-planning/navigation
     version: 0332151fd7628dddce5df1b1e69e1e251b4c4dec
-  perception_pcl:
-    type: git
-    url: https://github.com/ros-perception/perception_pcl
-    version: 539b5a78b2fb0f0004911c8f85d43a3cc0472625
-


### PR DESCRIPTION
The new Kinetic release fixes the issue with pcl and vtk, so the workaround of rebuilding from source within the workspace is no longer needed.

See:
 * https://github.com/ros/rosdistro/issues/27538 issue
 * https://discourse.ros.org/t/new-packages-for-kinetic-kame-2020-12-07/17786 discourse announcement

Signed-off-by: Zachary Michaels <zacmicha@amazon.com>