### PR TITLE
Delete cache if the bundle operation did not succeed.

### DIFF
--- a/colcon_bundle/verb/_archive_generators.py
+++ b/colcon_bundle/verb/_archive_generators.py
@@ -123,11 +123,13 @@ def generate_archive_v2(path_context: PathContext,
     print('Archiving complete!')
     _mark_cache_valid(path_context)
 
+
 def _mark_cache_valid(path_context):
     cache_valid_file = path_context.cache_valid_path()
     with open(cache_valid_file, 'a'):
         os.utime(cache_valid_file)
-    
+
+
 def recursive_tar_in_path(tar_path, path):
     """
     Tar all files inside a directory.

--- a/colcon_bundle/verb/_archive_generators.py
+++ b/colcon_bundle/verb/_archive_generators.py
@@ -121,8 +121,13 @@ def generate_archive_v2(path_context: PathContext,
 
     logger.info('Archiving complete')
     print('Archiving complete!')
+    _mark_cache_valid(path_context)
 
-
+def _mark_cache_valid(path_context):
+    cache_valid_file = path_context.cache_valid_path()
+    with open(cache_valid_file, 'a'):
+        os.utime(cache_valid_file)
+    
 def recursive_tar_in_path(tar_path, path):
     """
     Tar all files inside a directory.

--- a/colcon_bundle/verb/_path_context.py
+++ b/colcon_bundle/verb/_path_context.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import shutil
 
 from colcon_bundle.verb import check_and_mark_bundle_tool, \
     check_and_mark_bundle_version, \
@@ -47,6 +48,9 @@ class PathContext:
         self._bundle_cache = self._bundle_base
         if cache_version == 2:
             self._bundle_cache = os.path.join(self._bundle_base, 'cache')
+            if not os.path.exists(self.cache_valid_path()):
+                print('Cache is not valid. Clearing cache...')
+                shutil.rmtree(self._bundle_cache)
             os.makedirs(self._bundle_cache, exist_ok=True)
         self._install_base = install_base
 
@@ -125,3 +129,7 @@ class PathContext:
     def sources_tar_gz_path(self):  # noqa: D400
         """:return: File path for sources files tarball"""
         return os.path.join(self._bundle_base, 'sources.tar.gz')
+
+    def cache_valid_path(self):  # noqa: D400
+        """:return: File path for cache valid file."""
+        return os.path.join(self._bundle_cache, '.valid')

--- a/colcon_bundle/verb/_path_context.py
+++ b/colcon_bundle/verb/_path_context.py
@@ -50,7 +50,7 @@ class PathContext:
             self._bundle_cache = os.path.join(self._bundle_base, 'cache')
             if os.path.exists(self.cache_valid_path()):
                 os.remove(self.cache_valid_path())
-            else:
+            elif os.path.exists(self._bundle_cache):
                 print('Cache is not valid. Clearing cache...')
                 shutil.rmtree(self._bundle_cache)
             os.makedirs(self._bundle_cache, exist_ok=True)

--- a/colcon_bundle/verb/_path_context.py
+++ b/colcon_bundle/verb/_path_context.py
@@ -48,7 +48,9 @@ class PathContext:
         self._bundle_cache = self._bundle_base
         if cache_version == 2:
             self._bundle_cache = os.path.join(self._bundle_base, 'cache')
-            if not os.path.exists(self.cache_valid_path()):
+            if os.path.exists(self.cache_valid_path()):
+                os.remove(self.cache_valid_path())
+            else:
                 print('Cache is not valid. Clearing cache...')
                 shutil.rmtree(self._bundle_cache)
             os.makedirs(self._bundle_cache, exist_ok=True)


### PR DESCRIPTION
For bundle v2, it is possible that a broken bundle can be produced if the previous run did not succeed because the old cache is loaded. 

This change adds a `.valid` file to the bundle cache after a v2 bundle is created.
On subsequent builds:
* if the `.valid` file exists: it is removed so this current build's cache will not be used if it fails to bundle.
* if the `.valid` file does not exist: the cache is cleared

Signed-off-by: Zachary Michaels <zacmicha@amazon.com>