### PR TITLE
Skip tests requiring debian on other platforms

### DIFF
--- a/test/installer/test_apt_installer.py
+++ b/test/installer/test_apt_installer.py
@@ -63,11 +63,13 @@ class AptInstallerTests(unittest.TestCase):
                 shutil.rmtree(prefix)
                 os.remove(sources_list)
 
+    @unittest.skipIf(not os.path.isfile('/etc/debian_release'), "requires a debian distro")
     def test_apt_add_to_install_list_splits_version_specifier(self):
         package_name = "foo"
         package_version = "1.3.4"
         self._run_add_to_install_list_test(package_name, package_version)
 
+    @unittest.skipIf(not os.path.isfile('/etc/debian_release'), "requires a debian distro")
     def test_apt_add_to_install_list(self):
         package_name = "foo"
         self._run_add_to_install_list_test(package_name, '')


### PR DESCRIPTION
These two tests will fail if run on a non-Ubuntu distribution. It is simple enough to just skip them so that the other tests in the file can still be run.