### PR TITLE
Prevent pip from upgrading to v21 for Xenial

### DIFF
--- a/Dockerfile.backwards
+++ b/Dockerfile.backwards
@@ -16,21 +16,8 @@ RUN	rosdep update && \
 # NOTE: This is a workaround for setuptools 50.* (see https://github.com/pypa/setuptools/issues/2352)
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 
-RUN pip3 install --upgrade pip setuptools
+RUN pip3 install --upgrade pip==20.* setuptools==44.0.0
 RUN pip3 install -r requirements.txt
-RUN pip3 install colcon-bundle
-
-WORKDIR /opt/package/integration/test_workspace
-RUN source /opt/ros/kinetic/setup.sh; colcon build
-RUN source /opt/ros/kinetic/setup.sh; colcon bundle --bundle-version 1 --bundle-base v1
-RUN source /opt/ros/kinetic/setup.sh; colcon bundle --bundle-version 2 --bundle-base v2
-
-RUN rm -rf v1/output.tar.gz
-RUN rm -rf v2/output.tar
-
-WORKDIR /opt/package
-
-RUN pip3 uninstall -y colcon-bundle
 RUN pip3 install -e .
 
 WORKDIR /opt/package/integration/test_workspace

--- a/Dockerfile.backwards
+++ b/Dockerfile.backwards
@@ -17,7 +17,21 @@ RUN	rosdep update && \
 ENV SETUPTOOLS_USE_DISTUTILS=stdlib
 
 RUN pip3 install --upgrade pip==20.* setuptools==44.0.0
+RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
+RUN pip3 install colcon-bundle
+
+WORKDIR /opt/package/integration/test_workspace
+RUN source /opt/ros/kinetic/setup.sh; colcon build
+RUN source /opt/ros/kinetic/setup.sh; colcon bundle --bundle-version 1 --bundle-base v1
+RUN source /opt/ros/kinetic/setup.sh; colcon bundle --bundle-version 2 --bundle-base v2
+
+RUN rm -rf v1/output.tar.gz
+RUN rm -rf v2/output.tar
+
+WORKDIR /opt/package
+
+RUN pip3 uninstall -y colcon-bundle
 RUN pip3 install -e .
 
 WORKDIR /opt/package/integration/test_workspace

--- a/colcon_bundle/installer/base_pip_installer.py
+++ b/colcon_bundle/installer/base_pip_installer.py
@@ -85,6 +85,8 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
         pip_install_args = python_pip_args + ['install']
         subprocess.check_call(
             pip_install_args + ['-U', 'pip==20.*', 'setuptools==44.0.0'])
+        subprocess.check_call(
+            pip_install_args + ['-U', 'pip'])
 
         with open(requirements_file, 'w') as req:
             for name in self._packages:

--- a/colcon_bundle/installer/base_pip_installer.py
+++ b/colcon_bundle/installer/base_pip_installer.py
@@ -84,7 +84,7 @@ class BasePipInstallerExtensionPoint(BundleInstallerExtensionPoint):
         python_pip_args = [self._python_path, '-m', 'pip']
         pip_install_args = python_pip_args + ['install']
         subprocess.check_call(
-            pip_install_args + ['-U', 'pip', 'setuptools==44.0.0'])
+            pip_install_args + ['-U', 'pip==20.*', 'setuptools==44.0.0'])
 
         with open(requirements_file, 'w') as req:
             for name in self._packages:

--- a/test/installer/test_pip3_installer.py
+++ b/test/installer/test_pip3_installer.py
@@ -46,7 +46,7 @@ def test_install(check_output, check_call):
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
         assert args[1:] == [
-            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
+            '-m', 'pip', 'install', '-U', 'pip==20.*', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -97,7 +97,7 @@ def test_install_with_additional_arguments(check_output, check_call):
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
         assert args[1:] == [
-            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
+            '-m', 'pip', 'install', '-U', 'pip==20.*', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -150,7 +150,7 @@ def test_install_not_required(check_output, check_call):
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
         assert args[1:] == [
-            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
+            '-m', 'pip', 'install', '-U', 'pip==20.*', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -217,7 +217,7 @@ def test_install_additional_requirements(check_output, check_call):
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
         assert args[1:] == [
-            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
+            '-m', 'pip', 'install', '-U', 'pip==20.*', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path

--- a/test/installer/test_pip_installer.py
+++ b/test/installer/test_pip_installer.py
@@ -46,7 +46,7 @@ def test_install(check_output, check_call):
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
         assert args[1:] == [
-            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
+            '-m', 'pip', 'install', '-U', 'pip==20.*', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -97,7 +97,7 @@ def test_install_with_additional_arguments(check_output, check_call):
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
         assert args[1:] == [
-            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
+            '-m', 'pip', 'install', '-U', 'pip==20.*', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -149,7 +149,7 @@ def test_install_not_required(check_output, check_call):
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
         assert args[1:] == [
-            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
+            '-m', 'pip', 'install', '-U', 'pip==20.*', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path
@@ -216,7 +216,7 @@ def test_install_addtional_requirements(check_output, check_call):
         assert args[0] == python_path
         # Ensure we upgrade pip/setuptools
         assert args[1:] == [
-            '-m', 'pip', 'install', '-U', 'pip', 'setuptools==44.0.0']
+            '-m', 'pip', 'install', '-U', 'pip==20.*', 'setuptools==44.0.0']
 
         args = args_list[1][0][0]
         assert args[0] == python_path


### PR DESCRIPTION
Force pip to stay on 20.x version.

This PR also removes a portion of the backwards compatibility integration test that relies on pip installing the latest version of colcon, which will cause the integration test to fail since it will upgrade pip to v21.

See https://pip.pypa.io/en/stable/news/#id1 release notes for v21.0, which states that support for python 3.5 is dropped.

See https://github.com/pypa/pip/issues/9515 for some more information

Similar fixes:
https://github.com/ros-tooling/setup-ros-docker/pull/39
https://github.com/ros-tooling/setup-ros/pull/337

Signed-off-by: Jesse Ikawa <jikawa@amazon.com>