### PR TITLE
Update apt_package_blacklist.txt

### DIFF
--- a/colcon_bundle/installer/assets/apt_package_blacklist.txt
+++ b/colcon_bundle/installer/assets/apt_package_blacklist.txt
@@ -106,3 +106,7 @@ libignition-fuel-tools1-1
 libignition-math4
 libignition-msgs
 libignition-transport4
+gazebo11
+gazebo11-common
+gazebo11-plugin-base
+libgazebo11


### PR DESCRIPTION
Update blacklist to include Gazebo 11.

We blacklist Gazebo in order to reduce the size of the bundles that are created. We run bundles in an environment where Gazebo is already installed, so Gazebo is not needed in the bundle. If someone wants to include Gazebo they can override this blacklist with the --apt-package-blacklist argument.