### PR TITLE
Update expired OSRF gpg key

### DIFF
--- a/Dockerfile.backwards
+++ b/Dockerfile.backwards
@@ -7,6 +7,9 @@ RUN echo "yaml https://s3-us-west-2.amazonaws.com/rosdep/base.yaml" > /etc/ros/r
 COPY . /opt/package
 WORKDIR /opt/package
 
+RUN (apt-get update || true) && apt-get install --no-install-recommends --yes curl
+RUN curl --fail --show-error --silent --location https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+
 RUN apt-get update && \
 	apt-get install -y \
         enchant \

--- a/Dockerfile.dashing
+++ b/Dockerfile.dashing
@@ -5,6 +5,9 @@ SHELL ["/bin/bash", "-c"]
 COPY . /opt/package
 WORKDIR /opt/package
 
+RUN (apt-get update || true) && apt-get install --no-install-recommends --yes curl
+RUN curl --fail --show-error --silent --location https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+
 # install packages
 RUN apt-get update && apt-get upgrade -y && apt-get install -q -y \
     bash-completion \
@@ -14,7 +17,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -q -y \
     python3-apt \
     wget \
     enchant \
-    curl \
     sudo \
     wget
 

--- a/Dockerfile.double
+++ b/Dockerfile.double
@@ -7,6 +7,9 @@ RUN echo "yaml https://s3-us-west-2.amazonaws.com/rosdep/base.yaml" > /etc/ros/r
 COPY . /opt/package
 WORKDIR /opt/package
 
+RUN (apt-get update || true) && apt-get install --no-install-recommends --yes curl
+RUN curl --fail --show-error --silent --location https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+
 RUN apt-get update && \
 	apt-get install -y python3-pip python3-apt python-pip enchant sudo wget
 

--- a/Dockerfile.foxy
+++ b/Dockerfile.foxy
@@ -5,6 +5,9 @@ SHELL ["/bin/bash", "-c"]
 COPY . /opt/package
 WORKDIR /opt/package
 
+RUN (apt-get update || true) && apt-get install --no-install-recommends --yes curl
+RUN curl --fail --show-error --silent --location https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+
 # install packages
 RUN apt-get update && apt-get upgrade -y && apt-get install -q -y \
     bash-completion \
@@ -14,7 +17,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -q -y \
     python3-apt \
     wget \
     enchant \
-    curl \
     sudo \
     wget
 

--- a/Dockerfile.melodic
+++ b/Dockerfile.melodic
@@ -2,6 +2,9 @@ FROM ros:melodic
 
 SHELL ["/bin/bash", "-c"]
 
+RUN (apt-get update || true) && apt-get install --no-install-recommends --yes curl
+RUN curl --fail --show-error --silent --location https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+
 RUN apt-get update && \
         apt-get install -y wget && \
 	wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - && \


### PR DESCRIPTION
Add command to docker files to update the expired OSRF gpg key.
ROS Discourse post regarding the gpg expiration incident:
https://discourse.ros.org/t/ros-gpg-key-expiration-incident/20669/27

Signed-off-by: Jesse Ikawa <jikawa@amazon.com>